### PR TITLE
Added shortcode utils

### DIFF
--- a/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ShortcodeUtilsTest.java
+++ b/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ShortcodeUtilsTest.java
@@ -1,0 +1,25 @@
+package org.wordpress.android.util;
+
+import android.test.InstrumentationTestCase;
+
+public class ShortcodeUtilsTest extends InstrumentationTestCase {
+    public void testGetVideoPressShortcodeFromId() {
+        assertEquals("[wpvideo abcd1234]", ShortcodeUtils.getVideoPressShortcodeFromId("abcd1234"));
+    }
+
+    public void testGetVideoPressShortcodeFromNullId() {
+        assertEquals("", ShortcodeUtils.getVideoPressShortcodeFromId(null));
+    }
+
+    public void testGetVideoPressIdFromCorrectShortcode() {
+        assertEquals("abcd1234", ShortcodeUtils.getVideoPressIdFromShortCode("[wpvideo abcd1234]"));
+    }
+
+    public void testGetVideoPressIdFromInvalidShortcode() {
+        assertEquals("", ShortcodeUtils.getVideoPressIdFromShortCode("[other abcd1234]"));
+    }
+
+    public void testGetVideoPressIdFromNullShortcode() {
+        assertEquals("", ShortcodeUtils.getVideoPressIdFromShortCode(null));
+    }
+}

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ShortcodeUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ShortcodeUtils.java
@@ -1,0 +1,31 @@
+package org.wordpress.android.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ShortcodeUtils {
+    public static String getVideoPressShortcodeFromId(String videoPressId) {
+        if (videoPressId == null || videoPressId.isEmpty()) {
+            return "";
+        }
+
+        return "[wpvideo " + videoPressId + "]";
+    }
+
+    public static String getVideoPressIdFromShortCode(String shortcode) {
+        String videoPressId = "";
+
+        if (shortcode != null) {
+            String videoPressShortcodeRegex = "^\\[wpvideo (.*)]$";
+
+            Pattern pattern = Pattern.compile(videoPressShortcodeRegex);
+            Matcher matcher = pattern.matcher(shortcode);
+
+            if (matcher.find()) {
+                videoPressId = matcher.group(1);
+            }
+        }
+
+        return videoPressId;
+    }
+}

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class StringUtils {
     public static String[] mergeStringArrays(String array1[], String array2[]) {
@@ -226,6 +227,28 @@ public class StringUtils {
             offset += Character.charCount(codepoint);
         }
         return out.toString();
+    }
+
+    /**
+     * Used to convert a language code ([lc]_[rc] where lc is language code (en, fr, es, etc...)
+     * and rc is region code (zh-CN, zh-HK, zh-TW, etc...) to a displayable string with the languages
+     * name.
+     *
+     * The input string must be between 2 and 6 characters, inclusive. An empty string is returned
+     * if that is not the case.
+     *
+     * If the input string is recognized by {@link Locale} the result of this method is the given
+     *
+     * @return
+     *  non-null
+     */
+    public static String getLanguageString(String languagueCode, Locale displayLocale) {
+        if (languagueCode == null || languagueCode.length() < 2 || languagueCode.length() > 6) {
+            return "";
+        }
+
+        Locale languageLocale = new Locale(languagueCode.substring(0, 2));
+        return languageLocale.getDisplayLanguage(displayLocale) + languagueCode.substring(2);
     }
 
     /**

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -11,7 +11,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 public class StringUtils {
     public static String[] mergeStringArrays(String array1[], String array2[]) {
@@ -217,28 +216,6 @@ public class StringUtils {
             offset += Character.charCount(codepoint);
         }
         return out.toString();
-    }
-
-    /**
-     * Used to convert a language code ([lc]_[rc] where lc is language code (en, fr, es, etc...)
-     * and rc is region code (zh-CN, zh-HK, zh-TW, etc...) to a displayable string with the languages
-     * name.
-     *
-     * The input string must be between 2 and 6 characters, inclusive. An empty string is returned
-     * if that is not the case.
-     *
-     * If the input string is recognized by {@link Locale} the result of this method is the given
-     *
-     * @return
-     *  non-null
-     */
-    public static String getLanguageString(String languagueCode, Locale displayLocale) {
-        if (languagueCode == null || languagueCode.length() < 2 || languagueCode.length() > 6) {
-            return "";
-        }
-
-        Locale languageLocale = new Locale(languagueCode.substring(0, 2));
-        return languageLocale.getDisplayLanguage(displayLocale) + languagueCode.substring(2);
     }
 
     /**


### PR DESCRIPTION
Adds a new `ShortcodeUtils` class for string manipulations involving shortcodes.

For now the class just handles converting VideoPress shortcodes (`[wpvideo abcd1234]`) to VideoPress IDs (`abcd1234`) and vice versa. This will be used for video insertion in the visual editor.

cc @tonyr59h
