### PR TITLE
New MapUtils.getMapDouble/getMapFloat methods

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/MapUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/MapUtils.java
@@ -47,6 +47,28 @@ public class MapUtils {
         }
     }
 
+    public static float getMapFloat(final Map<?, ?> map, final String key) {
+        return getMapFloat(map, key, 0);
+    }
+    public static float getMapFloat(final Map<?, ?> map, final String key, long defaultValue) {
+        try {
+            return Float.parseFloat(getMapStr(map, key));
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public static double getMapDouble(final Map<?, ?> map, final String key) {
+        return getMapDouble(map, key, 0);
+    }
+    public static double getMapDouble(final Map<?, ?> map, final String key, long defaultValue) {
+        try {
+            return Double.parseDouble(getMapStr(map, key));
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
     /*
      * returns a date object from the passed key in the passed map
      * returns null if key doesn't exist or isn't a date


### PR DESCRIPTION
New MapUtils.getMapDouble/getMapFloat methods - this is necessary to write a clean fix for this issue: https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/164
