### PR TITLE
Matching type of defaultValue to the method return type

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/MapUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/MapUtils.java
@@ -47,10 +47,13 @@ public class MapUtils {
         }
     }
 
+    /*
+     * float version of above
+     */
     public static float getMapFloat(final Map<?, ?> map, final String key) {
         return getMapFloat(map, key, 0);
     }
-    public static float getMapFloat(final Map<?, ?> map, final String key, long defaultValue) {
+    public static float getMapFloat(final Map<?, ?> map, final String key, float defaultValue) {
         try {
             return Float.parseFloat(getMapStr(map, key));
         } catch (NumberFormatException e) {
@@ -58,10 +61,13 @@ public class MapUtils {
         }
     }
 
+    /*
+     * double version of above
+     */
     public static double getMapDouble(final Map<?, ?> map, final String key) {
         return getMapDouble(map, key, 0);
     }
-    public static double getMapDouble(final Map<?, ?> map, final String key, long defaultValue) {
+    public static double getMapDouble(final Map<?, ?> map, final String key, double defaultValue) {
         try {
             return Double.parseDouble(getMapStr(map, key));
         } catch (NumberFormatException e) {
@@ -74,7 +80,7 @@ public class MapUtils {
      * returns null if key doesn't exist or isn't a date
      */
     public static Date getMapDate(final Map<?, ?> map, final String key) {
-        if (map==null || key==null || !map.containsKey(key))
+        if (map == null || key == null || !map.containsKey(key))
             return null;
         try {
             return (Date) map.get(key);


### PR DESCRIPTION
2892e26fc983b4d87ee4dc79e2c0588ea4c1c8cb added two new utility methods with `long` default value types which should be `float`/`double`.

cc @aforcier
