### PR TITLE
Support IDN with emojis

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -54,11 +54,11 @@ public class UrlUtils {
     public static String convertUrlToPunycodeIfNeeded(String url) {
         if (!Charset.forName("US-ASCII").newEncoder().canEncode(url)) {
             if (url.toLowerCase().startsWith("http://")) {
-                url = "http://" + IDN.toASCII(url.substring(7));
+                url = "http://" + IDN.toASCII(url.substring(7), IDN.ALLOW_UNASSIGNED);
             } else if (url.toLowerCase().startsWith("https://")) {
-                url = "https://" + IDN.toASCII(url.substring(8));
+                url = "https://" + IDN.toASCII(url.substring(8), IDN.ALLOW_UNASSIGNED);
             } else {
-                url = IDN.toASCII(url);
+                url = IDN.toASCII(url, IDN.ALLOW_UNASSIGNED);
             }
         }
         return url;


### PR DESCRIPTION
From the documentation:

> If the ALLOW_UNASSIGNED flag is used, the domain name string to be converted can contain code points that are unassigned in Unicode 3.2, which is the Unicode version on which IDN conversion is based. If the flag is not used, the presence of such unassigned code points is treated as an error. 

Note: First emojis appeared in version 4.0 of Unicode, thus this flag is a must if we want to support URLs like http://💩.wpmt.co/