### PR TITLE
Update Bintray config

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        versionName "1.22"
+        versionName "1.23"
         minSdkVersion 15
         targetSdkVersion 26
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.novoda:bintray-release:0.8.1'
+        classpath 'com.novoda:bintray-release:0.9'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,4 +32,10 @@ allprojects {
             configFile file("${project.rootDir}/config/checkstyle.xml")
         }
     }
+
+    // Suppress false Javadoc lint errors preventing Bintray release
+    // See https://stackoverflow.com/questions/34828426/disable-javadoc-check-for-bintray-upload
+    tasks.withType(Javadoc) {
+        options.addBooleanOption('Xdoclint:none', true)
+    }
 }


### PR DESCRIPTION
This updates the build config so the project can be released to Bintray again.

Updating to the latest version (`0.9`) of the Gradle `bintray-release` plugin was required to support the new Gradle version we recently bumped the library to. However, this caused `./gradlew publishToMavenLocal` (part of the `bintrayUpload` preliminaries) to fail with errors (14 errors, all similar):

```
/.../WordPress-Utils-Android/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java:22: error: reference not found
     * @param context {@link Context} in which this layout is used.
```

This seemed to happen for all method declarations that had Javadocs using `{@link ...}`. I initially thought it was related to this block:

https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/b6abdcae2aeff3b310c87798fbac795f720684ea/WordPressUtils/build.gradle#L43-L58

But that doesn't seem to be the case, as the problem persisted even with that block removed.

Some digging, and trial and error led me to a few discussions of similar-sounding problems plus solutions - this one is the most concise:

https://stackoverflow.com/questions/34828426/disable-javadoc-check-for-bintray-upload

Basically I added an argument to suppress the Javadoc lint errors to allow the build to continue. IMO it would be better to understand why we're getting the errors and correct the build, but given that the project can be released correctly and the Javadoc comments and links are correct in the artifact, this felt like about as much time as I was willing to spend on the problem for the moment.

### To test

Change the library version and make a dummy release using:

```
$ ./gradlew assemble test bintrayUpload -PbintrayUser=FIXME -PbintrayKey=FIXME -PdryRun=false
```

I also recommend reverting the change in 81f224b locally and attempting the same command as above, to see the lint errors.

Make sure it succeeds, then build a project (e.g. [WordPress-Login-Flow-Android](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android)) that imports the `utils` library as an artifact, using the version you released (or - I've already pushed a `1.23` from this branch).

Ensure the project builds, and check that Javadocs are present.