### PR TITLE
A fix for a crash when uploading media on certain devices

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/FileUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/FileUtils.java
@@ -1,10 +1,25 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import org.wordpress.android.util.AppLog.T;
+
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.wordpress.android.util.MediaUtils.getPath;
 
 public class FileUtils {
+    public static final String DOCUMENTS_DIR = "documents";
     /**
      * Returns the length of the file denoted by this abstract pathname.
      * The return value is unspecified if this pathname denotes a directory.
@@ -57,5 +72,128 @@ public class FileUtils {
             filename = filePath;
         }
         return filename;
+    }
+
+    /**
+     * This solution is based on https://stackoverflow.com/a/53021624
+     * In certain cases we cannot load a file from the disk so we have to cache it instead using streams.
+     * The helper methods are copied from - https://github.com/coltoscosmin/FileUtils/blob/master/FileUtils.java
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     */
+    static String cacheFile(Context context, Uri uri) {
+        String fileName = getFileName(context, uri);
+        File cacheDir = getDocumentCacheDir(context);
+        File file = generateFileName(fileName, cacheDir);
+        String destinationPath = null;
+        if (file != null) {
+            destinationPath = file.getAbsolutePath();
+            saveFileFromUri(context, uri, destinationPath);
+        }
+        return destinationPath;
+    }
+
+    private static String getFileName(Context context, Uri uri) {
+        String mimeType = context.getContentResolver().getType(uri);
+        String filename = null;
+
+        if (mimeType == null) {
+            String path = getPath(context, uri);
+            if (path == null) {
+                filename = getName(uri.toString());
+            } else {
+                File file = new File(path);
+                filename = file.getName();
+            }
+        } else {
+            Cursor returnCursor = context.getContentResolver().query(uri, null,
+                    null, null, null);
+            if (returnCursor != null) {
+                int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                returnCursor.moveToFirst();
+                filename = returnCursor.getString(nameIndex);
+                returnCursor.close();
+            }
+        }
+
+        return filename;
+    }
+
+    private static String getName(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        int index = filename.lastIndexOf('/');
+        return filename.substring(index + 1);
+    }
+
+    private static File getDocumentCacheDir(@NonNull Context context) {
+        File dir = new File(context.getCacheDir(), DOCUMENTS_DIR);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        return dir;
+    }
+
+    @Nullable
+    private static File generateFileName(@Nullable String name, File directory) {
+        if (name == null) {
+            return null;
+        }
+
+        File file = new File(directory, name);
+
+        if (file.exists()) {
+            String fileName = name;
+            String extension = "";
+            int dotIndex = name.lastIndexOf('.');
+            if (dotIndex > 0) {
+                fileName = name.substring(0, dotIndex);
+                extension = name.substring(dotIndex);
+            }
+
+            int index = 0;
+
+            while (file.exists()) {
+                index++;
+                name = fileName + '(' + index + ')' + extension;
+                file = new File(directory, name);
+            }
+        }
+
+        try {
+            if (!file.createNewFile()) {
+                return null;
+            }
+        } catch (IOException e) {
+            AppLog.e(T.UTILS, e);
+            return null;
+        }
+
+        return file;
+    }
+
+    private static void saveFileFromUri(Context context, Uri uri, String destinationPath) {
+        InputStream is = null;
+        BufferedOutputStream bos = null;
+        try {
+            is = context.getContentResolver().openInputStream(uri);
+            bos = new BufferedOutputStream(new FileOutputStream(destinationPath, false));
+            byte[] buf = new byte[1024];
+            is.read(buf);
+            do {
+                bos.write(buf);
+            } while (is.read(buf) != -1);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (is != null) is.close();
+                if (bos != null) bos.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -402,7 +402,7 @@ public class MediaUtils {
      * @param context The context.
      * @param uri The Uri to query.
      */
-    private static String getPath(final Context context, final Uri uri) {
+    static String getPath(final Context context, final Uri uri) {
         String path = getDocumentProviderPathKitkatOrHigher(context, uri);
 
         if (path != null) {
@@ -438,14 +438,29 @@ public class MediaUtils {
                 // TODO handle non-primary volumes
             } else if (isDownloadsDocument(uri)) { // DownloadsProvider
                 final String id = DocumentsContract.getDocumentId(uri);
-                try {
-                    final Uri contentUri = ContentUris.withAppendedId(
-                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-                    return getDataColumn(context, contentUri, null, null);
-                } catch (NumberFormatException e) {
-                    AppLog.e(AppLog.T.UTILS, "Can't read the path for file with ID " + id);
-                    return null;
+
+                if (id != null && id.startsWith("raw:")) {
+                    return id.substring(4);
                 }
+
+                String[] contentUriPrefixesToTry = new String[]{
+                        "content://downloads/public_downloads",
+                        "content://downloads/my_downloads",
+                        "content://downloads/all_downloads"
+                };
+
+                for (String contentUriPrefix : contentUriPrefixesToTry) {
+                    Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
+                    try {
+                        String path = getDataColumn(context, contentUri, null, null);
+                        if (path != null) {
+                            return path;
+                        }
+                    } catch (Exception e) {
+                        AppLog.e(AppLog.T.UTILS, "Error reading _data column for URI: " + contentUri, e);
+                    }
+                }
+                return FileUtils.cacheFile(context, uri);
             } else if (isMediaDocument(uri)) { // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/8978
This PR should fix a crash that I couldn't reproduce. However, googling the issue led me to [this solution](https://stackoverflow.com/a/53021624) to the same problem. I'm using methods from the [FileUtils](https://github.com/coltoscosmin/FileUtils/blob/master/FileUtils.java) with some modifications that should prevent this problem. 

This solution should cover all 3 possible file destinations ("content://downloads/public_downloads", "content://downloads/my_downloads", "content://downloads/all_downloads") + should fall back to loading the file into memory with a stream when everything else fails. 

@daniloercoli I'll ping you once I create a PR for the WPAndroid to test this change

To test:
* I couldn't reproduce this issue so I don't really know how to test it.