### PR TITLE
Mark DateTimeUtils.localDateToUTC and DateTimeUtils.nowUTC as deprecated

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:28.0.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.assertj:assertj-core:3.11.1'
+
     lintChecks 'org.wordpress:lint:1.0.1'
 }
 
@@ -34,7 +37,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        versionName "1.23"
+        versionName "1.24"
         minSdkVersion 15
         targetSdkVersion 26
     }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
@@ -112,13 +112,25 @@ public class DateTimeUtils {
     }
 
     /**
-     * Returns the current UTC date
+     * Returns the current UTC date.
+     *
+     * @deprecated This method doesn't work as expected and shouldn't be used in production code. It doesn't take
+     * into account that `Date` class uses TimeZone.getDefault(). It substracts the currentOffsetFromUTC, but the
+     * final date still uses system default timezone.
      */
+    @Deprecated
     public static Date nowUTC() {
         Date dateTimeNow = new Date();
         return localDateToUTC(dateTimeNow);
     }
 
+    /**
+     *
+     * @deprecated This method doesn't work as expected and shouldn't be used in production code. It doesn't take
+     * into account that `Date` class uses TimeZone.getDefault(). It substracts the currentOffsetFromUTC, but the
+     * final date still uses system default timezone.
+     */
+    @Deprecated
     public static Date localDateToUTC(Date dtLocal) {
         if (dtLocal == null) {
             return null;

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/DateTimeUtilsTest.java
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/DateTimeUtilsTest.java
@@ -1,0 +1,45 @@
+package org.wordpress.android.util;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateTimeUtilsTest {
+    private final long mDefaultDate = 1564484058163L; // it's Tue Jul 30 2019 10:54:18 in UTC
+
+    @Test
+    public void testIso8601UTCFromDate() {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+2:00"));
+        Date date = new Date(mDefaultDate);
+
+        String expected = "2019-07-30T10:54:18+00:00";
+
+        String actual = DateTimeUtils.iso8601UTCFromDate(date);
+
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @Ignore(value = "This test is failing because `DateTimeUtils.localDateToUTC` doesn't work as expected. I've "
+                    + "marked it as deprecated and this tests serves just as a documentation.")
+    public void testLocalDateToUTC() {
+        // Arrange
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+2:00"));
+        Date date = new Date(mDefaultDate);
+        // this succeeds
+        assertThat(DateTimeUtils.iso8601FromDate(date)).isEqualTo("2019-07-30T12:54:18+0200");
+
+        // Act
+        String actual = DateTimeUtils.iso8601FromDate(DateTimeUtils.localDateToUTC(date));
+
+        // Assert
+
+        // fails because `localDateToUTC` doesn't work as expected. See DateTimeUtils.localDateToUTC for more info.
+        assertThat(actual).isEqualTo("2019-07-30T10:54:18+00:00");
+    }
+}

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/DateTimeUtilsTest.java
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/DateTimeUtilsTest.java
@@ -13,14 +13,15 @@ public class DateTimeUtilsTest {
 
     @Test
     public void testIso8601UTCFromDate() {
+        // Arrange
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+2:00"));
         Date date = new Date(mDefaultDate);
-
         String expected = "2019-07-30T10:54:18+00:00";
 
+        // Act
         String actual = DateTimeUtils.iso8601UTCFromDate(date);
 
-
+        // Assert
         assertThat(actual).isEqualTo(expected);
     }
 


### PR DESCRIPTION
DateTimeUtils.localDateToUTC and DateTimeUtils.nowUTC don't work as expected.

`java.Date` doesn't hold timezone information therefore there is no such thing as `UTC java.Date`. `java.Date` always uses system default timezone.

The intention of this method was to convert eg.
`Tue Jul 30 09:23:03 GMT+02:00 2019` -> `Tue Jul 30 07:23:03 GMT+00:00 2019`
but what it actually does is 
`Tue Jul 30 09:23:03 GMT+02:00 2019` -> `Tue Jul 30 07:23:03 GMT+02:00 2019`