### PR TITLE
Check if img source is null before checking for image smileys

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:3.5.1'
-        classpath 'com.novoda:bintray-release:0.9'
+        classpath 'com.novoda:bintray-release:0.9.1'
     }
 }
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/EmoticonsUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/EmoticonsUtils.java
@@ -72,6 +72,9 @@ public class EmoticonsUtils {
     }
 
     public static String lookupImageSmiley(String url, String ifNone) {
+        if (url == null) {
+            return ifNone;
+        }
         String file = url.substring(url.lastIndexOf("/") + 1);
         if (WP_SMILIES.containsKey(file)) {
             return WP_SMILIES.get(file);


### PR DESCRIPTION
Fixes #28 by checking if the img source is null when checking the [EmoticonsUtils](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/3117e2d9a39ff10ee01fb9b1177a37990220585e/WordPressUtils/src/main/java/org/wordpress/android/util/EmoticonsUtils.java#L85) class . 

#### To test
- Use this PR from woocommerce/woocommerce-android#2444.
- Set the description of a product to `<div><img /></div>` in `wp-admin`.
- Click on the product from the app.
- Notice the app no longer crashes.

This PR is in draft since this is a beta release. Once this PR is approved, we need to publish a new beta release before merging this PR.