### PR TITLE
ImageUtils: allow adding HTTP headers on getVideoFrameFromVideo()

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -52,7 +52,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        versionName "1.24"
+        versionName "1.25"
         minSdkVersion 18
         targetSdkVersion 26
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -608,6 +608,8 @@ public class ImageUtils {
      * Note that this method could take time if network url.
      *
      * @param videoPath The path to the video on internet
+     * @param maxWidth the maximumWidth for the thumbnail
+     * @param headers optional: HTTP headers map to add to the request if the video is remote
      * @return the path to the picture on disk
      */
     public static Bitmap getVideoFrameFromVideo(String videoPath, int maxWidth, Map<String, String> headers) {

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -609,6 +609,18 @@ public class ImageUtils {
      *
      * @param videoPath The path to the video on internet
      * @param maxWidth the maximumWidth for the thumbnail
+     * @return the path to the picture on disk
+     */
+    public static Bitmap getVideoFrameFromVideo(String videoPath, int maxWidth) {
+        return getVideoFrameFromVideo(videoPath, maxWidth, new HashMap<String, String>());
+    }
+
+    /**
+     * Generate a thumbnail from a video url.
+     * Note that this method could take time if network url.
+     *
+     * @param videoPath The path to the video on internet
+     * @param maxWidth the maximumWidth for the thumbnail
      * @param headers optional: HTTP headers map to add to the request if the video is remote
      * @return the path to the picture on disk
      */
@@ -628,11 +640,7 @@ public class ImageUtils {
         MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
         Bitmap bitmap = null;
         try {
-            if (headers != null) {
-                mediaMetadataRetriever.setDataSource(videoPath, headers);
-            } else {
-                mediaMetadataRetriever.setDataSource(videoPath, new HashMap<String, String>());
-            }
+            mediaMetadataRetriever.setDataSource(videoPath, headers);
             bitmap = mediaMetadataRetriever.getFrameAtTime();
         } catch (IllegalArgumentException e) {
             AppLog.e(AppLog.T.MEDIA, "The passed video path is invalid: " + videoPath);


### PR DESCRIPTION
This allows to pass headers (such as auth headers) to the [`MediaMetadataRetriever`](https://developer.android.com/reference/android/media/MediaMetadataRetriever) for remote videos when we need to get a video frame out of a video located remotely.

To test:
- Use https://github.com/wordpress-mobile/WordPress-Android/pull/12178

Once this PR is merged, I'll publish a  new release to bintray and change the reference in WPAndroid accordingly
