### PR TITLE
Make DefaultImage public so other GravatarUtils methods can use it

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -52,7 +52,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        versionName "1.25"
+        versionName "1.26"
         minSdkVersion 18
         targetSdkVersion 26
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
@@ -10,7 +10,7 @@ public class GravatarUtils {
     // it's up to the caller to catch the 404 and provide a suitable default image
     private static final DefaultImage DEFAULT_GRAVATAR = DefaultImage.MYSTERY_MAN;
 
-    private enum DefaultImage {
+    public enum DefaultImage {
         MYSTERY_MAN,
         STATUS_404,
         IDENTICON,


### PR DESCRIPTION
The [`GravatarUtils`](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/0463e2d3c0a52240217276cef4ca1c3b8c0e2f6f/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java) class has some methods that take its inner `DefaultImage` enum as a parameter, however `DefaultImage` was set to private, rendering those methods unusable by outside classes.

This PR makes `DefaultImage` public, so it can be be properly used by those methods again.