### PR TITLE
Adds components.release to Bintray publication

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -110,6 +110,7 @@ project.afterEvaluate {
     publishing {
         publications {
             UtilsPublication(MavenPublication) {
+                from components.release
                 groupId 'org.wordpress'
                 artifactId 'utils'
                 version android.defaultConfig.versionName


### PR DESCRIPTION
Publishing to Bintray with the latest changes for Gradle 6 didn't work as expected. It looks like we need to add `components.release` to the publication for the `aar` to be uploaded: https://developer.android.com/studio/build/maven-publish-plugin

There might still be something missing with the flow, but for the moment this change alone seems to be enough to get WPAndroid building with the latest utils binary release. One future consideration is the following paragraph from [gradle-bintray-plugin's README](https://github.com/bintray/gradle-bintray-plugin):

> If you are trying to publish an Android project, specifying the from components.java line in the above example is not applicable. Also, the POM file generated does not include the dependency chain so it must be explicitly added using this workaround.

I don't know if the workaround is necessary in our case, so I didn't add it yet.

_P.S: Note that merging this PR will diverge the utils repo from the subtree in WPAndroid, however that subtree should be removed by the end of the week and I'll merge the latest changes in WPAndroid to this repo, so it shouldn't be a problem._