### PR TITLE
Experiment: Bintray upload from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Build
           command: ./gradlew --stacktrace assembleDebug assembleRelease
       - android/save-gradle-cache
-  bintray-upload-from-branch:
+  Upload to Bintray:
     executor:
       name: android/default
       api-version: "27"
@@ -73,10 +73,6 @@ workflows:
       - Build:
           requires:
             - Test
-      - bintray-upload-from-branch:
+      - Upload to Bintray:
           requires:
             - Build
-          filters:
-            # Don't run on tags
-            tags:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,3 +76,15 @@ workflows:
       - Upload to Bintray:
           requires:
             - Build
+          filters:
+            tags:
+              ignore: /.*/
+  Bintray Release Build:
+    jobs:
+      - Build
+      - Upload to Bintray:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,14 +66,15 @@ workflows:
   # that's the default behavior
   WordPress-Utils-Android:
     jobs:
-      - Lint
-      - Test
-      - Build:
-          requires:
-            - Test
-      - Upload to Bintray:
-          requires:
-            - Build
+      # - Lint
+      # - Test
+      # - Build:
+      #     requires:
+      #       - Test
+      # - Upload to Bintray:
+      #     requires:
+      #       - Build
+      - Upload to Bintray
   # This is meant to run only on tags; we need to specify the filtering on
   # every job.
   Bintray Release Build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
       - android/save-gradle-cache
 
 workflows:
-  # This shall not run on tags, but no filter statement is necessary because
-  # that's the default behavior
+  # We don't want this to run on tags, but no filter statement is necessary
+  # because that's the default behavior
   WordPress-Utils-Android:
     jobs:
       # - Lint
@@ -97,25 +97,3 @@ workflows:
       #     requires:
       #       - Build
       - Upload to Bintray
-  # This is meant to run only on tags; we need to specify the filtering on
-  # every job.
-  Bintray Release Build:
-    jobs:
-      - Build:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              # only: /^\d+(\.\d+)*$/
-              # while testing, use any tag
-              only: /.*/
-      - Upload to Bintray:
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              # only: /^\d+(\.\d+)*$/
-              # while testing, use any tag
-              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,23 @@ jobs:
       - run:
           name: Experimental Bintray Upload
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
+            branch=$CIRCLE_BRANCH
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+              # Making the assumption that $CIRCLE_SHA1 will always be
+              # available. Also, cutting the full SHA into the first 7
+              # characters only because otherwise the upload of the .pom fails.
+              # Not sure why that would be the case, but it is.
+              PREFIX="$PR_NUMBER-${CIRCLE_SHA1:0:7}"
+            elif [[ "$branch" != "trunk" && "$branch" != "develop" && "$branch" != "master" ]]; then
+              # Checked on master as well for retro-compatibility.
+              # Once all of the projects have migrated to trunk, we shall remove
+              # that check.
+              echo "Running on a feature branch with no open PR: skipping Bintray upload"
+              exit 0
+            else
+              echo "Running on a production branch: skipping while trying to figure out a clean way to avoid republishing the same version."
+              exit 0
             fi
 
             # Locally, calling `./gradlew bintrayUpload` is enough to generate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,4 +89,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+(\.\d+)*$/
-      - Upload to Bintray
+      - Upload to Bintray:
+          requires:
+            - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,11 @@ jobs:
     steps:
       - checkout
       - copy-gradle-properties
-      # Trying without gradle cache to see if bintrayUpload works
-      # - android/restore-gradle-cache
+      - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
           command: ./gradlew --stacktrace assembleRelease bintrayUpload
-      # - android/save-gradle-cache
+      - android/save-gradle-cache
 
 workflows:
   # This shall not run on tags, but no filter statement is necessary because

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,23 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          # I'm out of ideas, trying to executed the two commands one after the
-          # other to see if it makes any difference
           command: |
+            # Locally, calling `./gradlew bintrayUpload` is enough to generate
+            # all the required artifacts. On CI, unless run each task
+            # individually, the Bintray task will fail to find the .aar and
+            # pom.xml artifacts in the build/ folder.
             ./gradlew --stacktrace assembleRelease
             # On local, the POM is generated automatically as part of
             # assembleRelease, but that doesn't seem to be the case on CI. Here
             # we need to explicitly generated it, otherwise bintrayUpload won't
             # find it and won't upload it.
+            #
+            # Worth noting that the Bintray plugin mentions the necessity for
+            # a workaround to generate the POM. See:
+            # https://github.com/bintray/gradle-bintray-plugin#maven-publications
+            #
+            # See also the description and comments in this PR:
+            # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
             ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication
             ./gradlew --stacktrace bintrayUpload
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,3 +76,7 @@ workflows:
       - Bintray Upload:
           requires:
             - Build
+          filters:
+            # Don't run on tags
+            tags:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,10 @@ jobs:
             #
             # See also the description and comments in this PR:
             # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
-            ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication
+            #
+            # Notice the `-PbintrayVersion` parameter to make sure the POM has
+            # the same version as the one bintrayUpload will use.
+            ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication -PbintrayVersion=$PREFIX
 
             # If $PREFIX is not set, that is, if we're not on a PR but a merge
             # commit on develop or trunk, the plugin will fallback to reading

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
-          name: Experimental Bintray Upload
+          name: Bintray Upload
           command: |
             branch=$CIRCLE_BRANCH
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
@@ -98,12 +98,8 @@ workflows:
   # because that's the default behavior
   WordPress-Utils-Android:
     jobs:
-      # - Lint
-      # - Test
-      # - Build:
-      #     requires:
-      #       - Test
-      # - Build and upload to Bintray:
-      #     requires:
-      #       - Build
-      - Build and upload to Bintray
+      - Lint
+      - Test
+      - Build and upload to Bintray:
+          requires:
+            - Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: "Test: Extract PR and Git info from env"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]]; then
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]] then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,6 @@ jobs:
             elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
               echo "Running on a feature branch with no open PR: skipping Bintray upload"
               exit 0
-            else
-              echo "Running on a production branch: skipping while trying to figure out a clean way to avoid republishing the same version."
-              exit 0
             fi
 
             # Locally, calling `./gradlew bintrayUpload` is enough to generate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,7 @@ jobs:
               # characters only because otherwise the upload of the .pom fails.
               # Not sure why that would be the case, but it is.
               PREFIX="$PR_NUMBER-${CIRCLE_SHA1:0:7}"
-            elif [[ "$branch" != "trunk" && "$branch" != "develop" && "$branch" != "master" ]]; then
-              # Checked on master as well for retro-compatibility.
-              # Once all of the projects have migrated to trunk, we shall remove
-              # that check.
+            elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
               echo "Running on a feature branch with no open PR: skipping Bintray upload"
               exit 0
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,16 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
+          name: "Test: Extract PR and Git info from env"
+          command: |
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            fi
+
+            echo "Prefix is $PREFIX"
+
+      - run:
           name: Experimental Bintray Upload
           command: |
             # Locally, calling `./gradlew bintrayUpload` is enough to generate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,11 @@ jobs:
       - run:
           name: Experimental Bintray Upload
           command: |
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            fi
+
             # Locally, calling `./gradlew bintrayUpload` is enough to generate
             # all the required artifacts. On CI, unless run each task
             # individually, the Bintray task will fail to find the .aar and
@@ -78,7 +83,11 @@ jobs:
             # See also the description and comments in this PR:
             # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
             ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication
-            ./gradlew --stacktrace bintrayUpload
+
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the plugin will fallback to reading
+            # the version value from the source code.
+            ./gradlew --stacktrace bintrayUpload -PbintrayVersion=$PREFIX
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,15 @@ jobs:
       - run:
           name: Bintray Upload
           command: |
+            # Use a different versioning style for builds from PRs to allow
+            # developers to iterate faster.
+            #
+            # All those dev builds will be deleted once the PR is merged by
+            # https://github.com/Automattic/bintray-garbage-collector/
+            #
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the version will be the value from
+            # the source code.
             branch=$CIRCLE_BRANCH
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
@@ -54,15 +63,23 @@ jobs:
               # available.
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
+              # This happens on the first push of a new branch, when there
+              # isn't a PR open for it yet.
               echo "Running on a feature branch with no open PR: skipping Bintray upload"
               exit 0
             fi
 
             # Locally, calling `./gradlew bintrayUpload` is enough to generate
             # all the required artifacts. On CI, unless run each task
-            # individually, the Bintray task will fail to find the .aar and
-            # pom.xml artifacts in the build/ folder.
+            # individually, the Bintray task will fail to find the AAR and
+            # POM artifacts in the build/ folder.
+            #
+            # This builds the AAR.
             ./gradlew --stacktrace assembleRelease
+
+
+            # This builds the POM.
+            #
             # On local, the POM is generated automatically as part of
             # assembleRelease, but that doesn't seem to be the case on CI. Here
             # we need to explicitly generated it, otherwise bintrayUpload won't
@@ -79,9 +96,7 @@ jobs:
             # the same version as the one bintrayUpload will use.
             ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication -PbintrayVersion=$PREFIX
 
-            # If $PREFIX is not set, that is, if we're not on a PR but a merge
-            # commit on develop or trunk, the plugin will fallback to reading
-            # the version value from the source code.
+            # Finally, this uploads both AAR and POM to Bintray.
             ./gradlew --stacktrace bintrayUpload -PbintrayVersion=$PREFIX
       - android/save-gradle-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Build
           command: ./gradlew --stacktrace assembleDebug assembleRelease
       - android/save-gradle-cache
-  Bintray Upload:
+  bintray-upload-from-branch:
     executor:
       name: android/default
       api-version: "27"
@@ -73,7 +73,7 @@ workflows:
       - Build:
           requires:
             - Test
-      - Bintray Upload:
+      - bintray-upload-from-branch:
           requires:
             - Build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,8 @@ jobs:
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               # Making the assumption that $CIRCLE_SHA1 will always be
-              # available. Also, cutting the full SHA into the first 7
-              # characters only because otherwise the upload of the .pom fails.
-              # Not sure why that would be the case, but it is.
-              PREFIX="$PR_NUMBER-${CIRCLE_SHA1:0:7}"
+              # available.
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
               echo "Running on a feature branch with no open PR: skipping Bintray upload"
               exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,14 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+  # This is meant to run only on tags. To do so, it's enough to have the filter
+  # requirement on the first job (?)
   Bintray Release Build:
     jobs:
-      - Build
-      - Upload to Bintray:
+      - Build:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^\d+(\.\d+)*$/
+      - Upload to Bintray

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: "Test: Extract PR and Git info from env"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]] then
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,10 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          # It's redundant to rebuild the release here when it's already done
-          # in the Build job. The only reason it's done like that is to keep
-          # them separated while testing
+          # It's a bit wasteful to rebuild here, when we already have an
+          # artifact available from the Build set.  Given the build time is
+          # around 90s, we can live with it for the moment and come back
+          # later to add caching
           command: ./gradlew --stacktrace assembleRelease bintrayUpload
       - android/save-gradle-cache
 
@@ -72,4 +73,6 @@ workflows:
       - Build:
           requires:
             - Test
-      - Bintray Upload
+      - Bintray Upload:
+          requires:
+            - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       # - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          command: ./gradlew --stacktrace bintrayUpload
+          command: ./gradlew --stacktrace assembleRelease bintrayUpload
       # - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,12 @@ jobs:
     steps:
       - checkout
       - copy-gradle-properties
-      - android/restore-gradle-cache
+      # Trying without gradle cache to see if bintrayUpload works
+      # - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
           command: ./gradlew --stacktrace bintrayUpload
-      - android/save-gradle-cache
+      # - android/save-gradle-cache
 
 workflows:
   # This shall not run on tags, but no filter statement is necessary because

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,11 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          command: ./gradlew --stacktrace assembleRelease bintrayUpload
+          # I'm out of ideas, trying to executed the two commands one after the
+          # other to see if it makes any difference
+          command: |
+            ./gradlew --stacktrace assembleRelease
+            ./gradlew --stacktrace bintrayUpload
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,10 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          command: ./gradlew --stacktrace bintrayUpload
+          # It's redundant to rebuild the release here when it's already done
+          # in the Build job. The only reason it's done like that is to keep
+          # them separated while testing
+          command: ./gradlew --stacktrace assembleRelease bintrayUpload
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
       name: android/default
       api-version: "27"
     steps:
+      - run:
+          command: |
+            echo $CIRCLE_PULL_REQUEST
+            echo $CIRCLE_PULL_REQUESTS
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,19 +36,7 @@ jobs:
           name: Test
           command: ./gradlew --stacktrace test
       - android/save-gradle-cache
-  Build:
-    executor:
-      name: android/default
-      api-version: "27"
-    steps:
-      - checkout
-      - copy-gradle-properties
-      - android/restore-gradle-cache
-      - run:
-          name: Build
-          command: ./gradlew --stacktrace assembleDebug assembleRelease
-      - android/save-gradle-cache
-  Upload to Bintray:
+  Build and upload to Bintray:
     executor:
       name: android/default
       api-version: "27"
@@ -93,7 +81,7 @@ workflows:
       # - Build:
       #     requires:
       #       - Test
-      # - Upload to Bintray:
+      # - Build and upload to Bintray:
       #     requires:
       #       - Build
-      - Upload to Bintray
+      - Build and upload to Bintray

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,7 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Experimental Bintray Upload
-          # It's a bit wasteful to rebuild here, when we already have an
-          # artifact available from the Build set.  Given the build time is
-          # around 90s, we can live with it for the moment and come back
-          # later to add caching
-          command: ./gradlew --stacktrace assembleRelease bintrayUpload
+          command: ./gradlew --stacktrace bintrayUpload
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ jobs:
       - android/save-gradle-cache
 
 workflows:
+  # This shall not run on tags, but no filter statement is necessary because
+  # that's the default behavior
   WordPress-Utils-Android:
     jobs:
       - Lint
@@ -76,11 +78,8 @@ workflows:
       - Upload to Bintray:
           requires:
             - Build
-          filters:
-            tags:
-              ignore: /.*/
-  # This is meant to run only on tags. To do so, it's enough to have the filter
-  # requirement on the first job (?)
+  # This is meant to run only on tags; we need to specify the filtering on
+  # every job.
   Bintray Release Build:
     jobs:
       - Build:
@@ -94,3 +93,10 @@ workflows:
       - Upload to Bintray:
           requires:
             - Build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # only: /^\d+(\.\d+)*$/
+              # while testing, use any tag
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,6 @@ jobs:
       name: android/default
       api-version: "27"
     steps:
-      - run:
-          command: |
-            echo $CIRCLE_PULL_REQUEST
-            echo $CIRCLE_PULL_REQUESTS
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+(\.\d+)*$/
+              # only: /^\d+(\.\d+)*$/
+              # while testing, use any tag
+              only: /.*/
       - Upload to Bintray:
           requires:
             - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,16 +49,6 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
-          name: "Test: Extract PR and Git info from env"
-          command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
-            fi
-
-            echo "Prefix is $PREFIX"
-
-      - run:
           name: Experimental Bintray Upload
           command: |
             if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,11 @@ jobs:
           # other to see if it makes any difference
           command: |
             ./gradlew --stacktrace assembleRelease
+            # On local, the POM is generated automatically as part of
+            # assembleRelease, but that doesn't seem to be the case on CI. Here
+            # we need to explicitly generated it, otherwise bintrayUpload won't
+            # find it and won't upload it.
+            ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication
             ./gradlew --stacktrace bintrayUpload
       - android/save-gradle-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,18 @@ jobs:
           name: Build
           command: ./gradlew --stacktrace assembleDebug assembleRelease
       - android/save-gradle-cache
+  Bintray Upload:
+    executor:
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - copy-gradle-properties
+      - android/restore-gradle-cache
+      - run:
+          name: Experimental Bintray Upload
+          command: ./gradlew --stacktrace bintrayUpload
+      - android/save-gradle-cache
 
 workflows:
   WordPress-Utils-Android:
@@ -57,3 +69,4 @@ workflows:
       - Build:
           requires:
             - Test
+      - Bintray Upload

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WordPress-Utils-Android
 
 
+
 Collection of utility methods for Android and WordPress.
 
 ## Use the library in your project

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 
+
 Collection of utility methods for Android and WordPress.
 
 ## Use the library in your project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # WordPress-Utils-Android
 
+
 Collection of utility methods for Android and WordPress.
 
 ## Use the library in your project

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -113,6 +113,10 @@ def getBintrayVersion() {
   // A more CI friendly option might be to just use the sha
   def tag = getGitTag()
 
+  // It's not ideal to access CI environment variables from here, since this
+  // code could be run locally as well. The reasons this is this way right now
+  // is because of the logic to extract the PR number.
+  //
   // See https://circleci.com/docs/2.0/env-vars/
   def prURL = System.getenv('CIRCLE_PULL_REQUEST')
   if (prURL) {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -127,6 +127,17 @@ def getBintrayVersion() {
     }
   }
 
+  // Not on a PR. Are we on master|trunk?
+  if (getGitBranch() == 'master') {
+    // On master|trunk use the library version; these are production releases
+    return android.defaultConfig.versionName
+  }
+
+  // Are we on develop?
+  if (getGitBranch() == 'develop') {
+    // TODO: only return version if it's a "-beta.n" one
+  }
+
   if (tag) {
     return tag
   } else {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -95,8 +95,8 @@ bintray {
     publish = true
     pkg {
         repo = 'maven'
-        name = 'utils'
-        userOrg = 'wordpress-mobile'
+        name = 'utils-experiment'
+        userOrg = 'mokagio'
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -54,7 +54,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionName "1.30"
+        versionName "1.30.1"
         minSdkVersion 18
         targetSdkVersion 29
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,6 +88,8 @@ android.libraryVariants.all { variant ->
     }
 }
 
+def bintrayVersion = android.defaultConfig.versionName
+
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
     key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
@@ -100,7 +102,7 @@ bintray {
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {
-            name = android.defaultConfig.versionName
+            name = bintrayVersion
             desc = 'Utils library for Android'
             released  = new Date()
         }
@@ -114,7 +116,7 @@ project.afterEvaluate {
                 from components.release
                 groupId 'org.wordpress'
                 artifactId 'utils'
-                version android.defaultConfig.versionName
+                version bintrayVersion
             }
         }
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -99,8 +99,8 @@ bintray {
     publish = true
     pkg {
         repo = 'maven'
-        name = 'utils-experiment'
-        userOrg = 'mokagio'
+        name = 'utils'
+        userOrg = 'wordpress-mobile'
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -96,7 +96,9 @@ def getCheckedOutGitCommitHash() {
   return 'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
-def bintrayVersion = "${getGitBranch()}-${getCheckedOutGitCommitHash()}"// android.defaultConfig.versionName
+def bintrayVersion() {
+  return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"// android.defaultConfig.versionName
+}
 
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -107,6 +107,10 @@ def getCheckedOutGitCommitHash() {
 }
 
 def getBintrayVersion() {
+  project.properties['bintrayVersion'] ?: getBintrayVersion_()
+}
+
+def getBintrayVersion_() {
   // One option could be to use "branch-sha" as the version
   // return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,65 +88,8 @@ android.libraryVariants.all { variant ->
     }
 }
 
-def getGitBranch() {
-  return 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
-}
-
-def getGitTag() {
-  def result = 'git describe --exact-match --tags HEAD'.execute().text.trim()
-
-  if (result.startsWith("fatal: no tag exactly matches")) {
-    return null
-  } else {
-    return result
-  }
-}
-
-def getCheckedOutGitCommitHash() {
-  return 'git rev-parse --verify --short HEAD'.execute().text.trim()
-}
-
 def getBintrayVersion() {
   return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
-}
-
-def getBintrayVersion_() {
-  // One option could be to use "branch-sha" as the version
-  // return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"
-
-  // A more CI friendly option might be to just use the sha
-  def tag = getGitTag()
-
-  // It's not ideal to access CI environment variables from here, since this
-  // code could be run locally as well. The reasons this is this way right now
-  // is because of the logic to extract the PR number.
-  //
-  // See https://circleci.com/docs/2.0/env-vars/
-  def prURL = System.getenv('CIRCLE_PULL_REQUEST')
-  if (prURL) {
-    def pr = prURL.split('/').last()
-
-    if (pr) {
-      return "${pr}-${getCheckedOutGitCommitHash()}"
-    }
-  }
-
-  // Not on a PR. Are we on master|trunk?
-  if (getGitBranch() == 'master') {
-    // On master|trunk use the library version; these are production releases
-    return android.defaultConfig.versionName
-  }
-
-  // Are we on develop?
-  if (getGitBranch() == 'develop') {
-    // TODO: only return version if it's a "-beta.n" one
-  }
-
-  if (tag) {
-    return tag
-  } else {
-    return getCheckedOutGitCommitHash()
-  }
 }
 
 bintray {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -107,7 +107,7 @@ def getCheckedOutGitCommitHash() {
 }
 
 def getBintrayVersion() {
-  project.properties['bintrayVersion'] ?: getBintrayVersion_()
+  return project.properties['bintrayVersion'] ?: getBintrayVersion_()
 }
 
 def getBintrayVersion_() {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -114,7 +114,7 @@ def getBintrayVersion() {
   def tag = getGitTag()
 
   // See https://circleci.com/docs/2.0/env-vars/
-  def pr = System.getenv('CIRCLE_PULL_REQUEST')
+  def pr = System.getenv('CIRCLE_PULL_REQUEST').split('/').last()
     if (pr) {
       return "${pr}-${getCheckedOutGitCommitHash()}"
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -113,6 +113,12 @@ def getBintrayVersion() {
   // A more CI friendly option might be to just use the sha
   def tag = getGitTag()
 
+  // See https://circleci.com/docs/2.0/env-vars/
+  def pr = System.getenv('CIRCLE_PR_NUMBER')
+    if (pr) {
+      return "${pr}-${getCheckedOutGitCommitHash()}"
+    }
+
   if (tag) {
     return tag
   } else {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,7 +88,15 @@ android.libraryVariants.all { variant ->
     }
 }
 
-def bintrayVersion = android.defaultConfig.versionName
+// Will this work on CI, though?
+def getGitBranch() {
+  return 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
+}
+def getCheckedOutGitCommitHash() {
+  return 'git rev-parse --verify --short HEAD'.execute().text.trim()
+}
+
+def bintrayVersion = "${getGitBranch()}-${getCheckedOutGitCommitHash()}"// android.defaultConfig.versionName
 
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -107,7 +107,7 @@ def getCheckedOutGitCommitHash() {
 }
 
 def getBintrayVersion() {
-  return project.properties['bintrayVersion'] ?: getBintrayVersion_()
+  return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
 }
 
 def getBintrayVersion_() {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,7 +88,6 @@ android.libraryVariants.all { variant ->
     }
 }
 
-// Will this work on CI, though?
 def getGitBranch() {
   return 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
 }
@@ -96,8 +95,12 @@ def getCheckedOutGitCommitHash() {
   return 'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
-def bintrayVersion() {
-  return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"// android.defaultConfig.versionName
+def getBintrayVersion() {
+  // One option could be to use "branch-sha" as the version
+  // return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"
+
+  // A more CI friendly option might be to just use the sha
+  return getCheckedOutGitCommitHash()
 }
 
 bintray {
@@ -112,7 +115,7 @@ bintray {
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {
-            name = bintrayVersion
+            name = getBintrayVersion()
             desc = 'Utils library for Android'
             released  = new Date()
         }
@@ -126,7 +129,7 @@ project.afterEvaluate {
                 from components.release
                 groupId 'org.wordpress'
                 artifactId 'utils'
-                version bintrayVersion
+                version getBintrayVersion()
             }
         }
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -114,10 +114,14 @@ def getBintrayVersion() {
   def tag = getGitTag()
 
   // See https://circleci.com/docs/2.0/env-vars/
-  def pr = System.getenv('CIRCLE_PULL_REQUEST').split('/').last()
+  def prURL = System.getenv('CIRCLE_PULL_REQUEST')
+  if (prURL) {
+    def pr = prURL.split('/').last()
+
     if (pr) {
       return "${pr}-${getCheckedOutGitCommitHash()}"
     }
+  }
 
   if (tag) {
     return tag

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -114,7 +114,7 @@ def getBintrayVersion() {
   def tag = getGitTag()
 
   // See https://circleci.com/docs/2.0/env-vars/
-  def pr = System.getenv('CIRCLE_PR_NUMBER')
+  def pr = System.getenv('CIRCLE_PULL_REQUEST')
     if (pr) {
       return "${pr}-${getCheckedOutGitCommitHash()}"
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -91,6 +91,17 @@ android.libraryVariants.all { variant ->
 def getGitBranch() {
   return 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
 }
+
+def getGitTag() {
+  def result = 'git describe --exact-match --tags HEAD'.execute().text.trim()
+
+  if (result.startsWith("fatal: no tag exactly matches")) {
+    return null
+  } else {
+    return result
+  }
+}
+
 def getCheckedOutGitCommitHash() {
   return 'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
@@ -100,7 +111,13 @@ def getBintrayVersion() {
   // return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"
 
   // A more CI friendly option might be to just use the sha
-  return getCheckedOutGitCommitHash()
+  def tag = getGitTag()
+
+  if (tag) {
+    return tag
+  } else {
+    return getCheckedOutGitCommitHash()
+  }
 }
 
 bintray {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -149,11 +149,15 @@ bintray {
     }
 }
 
+// Because the components are created only during the `afterEvaluate` phase, we
+// must configure our publications using the `afterEvaluate()` lifecycle method
 project.afterEvaluate {
     publishing {
         publications {
             UtilsPublication(MavenPublication) {
+                // Applies the component for the release build variant
                 from components.release
+
                 groupId 'org.wordpress'
                 artifactId 'utils'
                 version getBintrayVersion()


### PR DESCRIPTION
Here's my first stab at automatically upload the library artifact to Bintray from CI.

With this PR, every time a commit is pushed to the remote for a branch that has an open PR, a new build will be made and uploaded to Bintray with version `<PR number>-<commit sha>`, for example `40-f9bef32ac6cb1bfe57bcef21e79613d0af569334`.

My initial plan was to publish beta and stable builds from merges into `develop` and `trunk` respectively. Along the way, I realized that to do so we'd have to check Bintray to verify whether the current version value on the codebase has already been published because trying to publish a version that has already been published results in the task failing (on CI, locally it just say "skipping because there's already a binary for this version")

So, for the time being, I added a line to skip building on `develop` and `trunk`.

I see two options forwards:

- Implement this version check, which I think will require writing some Groovy or Kotlin code as a dedicated Gradle action to speak with the Bintray API and check if a version matching the value in `android.defaultConfig.versionName` is available
- Make the process less smart and more human driven, by publishing a build to Bintray when a tag is pushed to the repo (like we do for the iOS libraries, e.g. [Tracks](https://github.com/Automattic/Automattic-Tracks-iOS/blob/0cb87616f078207f717696adbe85b7100c863620/.circleci/config.yml#L59-L69))