### PR TITLE
Run unit tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
 
 jobs:
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:
@@ -25,7 +25,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Build:
-    executor: 
+    executor:
       name: android/default
       api-version: "27"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
           command: ./gradlew --stacktrace lint checkstyle
       - android/save-gradle-cache
       - android/save-lint-results
+  Test:
+    executor:
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - copy-gradle-properties
+      - android/restore-gradle-cache
+      - run:
+          name: Test
+          command: ./gradlew --stacktrace test
+      - android/save-gradle-cache
   Build:
     executor:
       name: android/default
@@ -41,4 +53,7 @@ workflows:
   WordPress-Utils-Android:
     jobs:
       - Lint
-      - Build
+      - Test
+      - Build:
+          requires:
+            - Test


### PR DESCRIPTION
I looked at the log for `.circleci/config.yml` and didn't see any rationale for not running the unit tests from CI.

My guess would be that since the library is setup as a subtree in the WordPress app, we simply used to trust its CI would run these tests, too.

Given we're moving towards binary builds, meaning that the source for this library won't be available in the WordPress codebase anymore, it seems appropriate to run the tests here, too.

## To test

To verify CI actually picks up failed tests, I opened [another PR](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/41) with an additional commit that switches a test expectation. [The CI workflow for that commit failed](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Utils-Android/102/workflows/d370b803-86cf-4002-8a70-1ad316091afc/jobs/198).