### PR TITLE
Add automation to auto publish builds to Bintray from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,9 @@ jobs:
             # find it and won't upload it.
             #
             # Worth noting that the Bintray plugin mentions the necessity for
-            # a workaround to generate the POM. See:
-            # https://github.com/bintray/gradle-bintray-plugin#maven-publications
+            # some workarounds to generate the POM under certain circumstances,
+            # although none of them apply to our current usage. See:
+            # https://github.com/bintray/gradle-bintray-plugin/tree/67718c3a65b64dbfe7534a82a178da2c57153a5d#maven-publications
             #
             # See also the description and comments in this PR:
             # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Test
           command: ./gradlew --stacktrace test
       - android/save-gradle-cache
-  Build:
+  Build and upload to Bintray:
     executor:
       name: android/default
       api-version: "27"
@@ -45,15 +45,67 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
-          name: Build
-          command: ./gradlew --stacktrace assembleDebug assembleRelease
+          name: Bintray Upload
+          command: |
+            # Use a different versioning style for builds from PRs to allow
+            # developers to iterate faster.
+            #
+            # All those dev builds will be deleted once the PR is merged by
+            # https://github.com/Automattic/bintray-garbage-collector/
+            #
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the version will be the value from
+            # the source code.
+            branch=$CIRCLE_BRANCH
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              # Making the assumption that $CIRCLE_SHA1 will always be
+              # available.
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
+              # This happens on the first push of a new branch, when there
+              # isn't a PR open for it yet.
+              echo "Running on a feature branch with no open PR: skipping Bintray upload"
+              exit 0
+            fi
+
+            # Locally, calling `./gradlew bintrayUpload` is enough to generate
+            # all the required artifacts. On CI, unless run each task
+            # individually, the Bintray task will fail to find the AAR and
+            # POM artifacts in the build/ folder.
+            #
+            # This builds the AAR.
+            ./gradlew --stacktrace assembleRelease
+
+            # This builds the POM.
+            #
+            # On local, the POM is generated automatically as part of
+            # assembleRelease, but that doesn't seem to be the case on CI. Here
+            # we need to explicitly generated it, otherwise bintrayUpload won't
+            # find it and won't upload it.
+            #
+            # Worth noting that the Bintray plugin mentions the necessity for
+            # a workaround to generate the POM. See:
+            # https://github.com/bintray/gradle-bintray-plugin#maven-publications
+            #
+            # See also the description and comments in this PR:
+            # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
+            #
+            # Notice the `-PbintrayVersion` parameter to make sure the POM has
+            # the same version as the one bintrayUpload will use.
+            ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication -PbintrayVersion=$PREFIX
+
+            # Finally, this uploads both AAR and POM to Bintray.
+            ./gradlew --stacktrace bintrayUpload -PbintrayVersion=$PREFIX
       - android/save-gradle-cache
 
 workflows:
+  # We don't want this to run on tags, but no filter statement is necessary
+  # because that's the default behavior
   WordPress-Utils-Android:
     jobs:
       - Lint
       - Test
-      - Build:
+      - Build and upload to Bintray:
           requires:
             - Test

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -54,7 +54,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionName "1.30"
+        versionName "1.30.1-beta.1"
         minSdkVersion 18
         targetSdkVersion 29
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -107,11 +107,17 @@ bintray {
     }
 }
 
+// Because the components are created only during the `afterEvaluate` phase, we
+// must configure our publications using the `afterEvaluate()` lifecycle method
+//
+// See https://developer.android.com/studio/build/maven-publish-plugin
 project.afterEvaluate {
     publishing {
         publications {
             UtilsPublication(MavenPublication) {
+                // Applies the component for the release build variant
                 from components.release
+
                 groupId 'org.wordpress'
                 artifactId 'utils'
                 version android.defaultConfig.versionName

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,6 +88,12 @@ android.libraryVariants.all { variant ->
     }
 }
 
+// Allows to override the artifact version by passing a -PbintrayVersion
+// parameter when calling Gradle
+def getBintrayVersion() {
+  return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
+}
+
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
     key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
@@ -100,7 +106,7 @@ bintray {
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {
-            name = android.defaultConfig.versionName
+            name = getBintrayVersion()
             desc = 'Utils library for Android'
             released  = new Date()
         }
@@ -120,7 +126,7 @@ project.afterEvaluate {
 
                 groupId 'org.wordpress'
                 artifactId 'utils'
-                version android.defaultConfig.versionName
+                version getBintrayVersion()
             }
         }
     }


### PR DESCRIPTION
This uses the work from #39 to run the `bintrayPublish` task from CI and allow us to have development builds for every push to a feature branch, as well as beta and release builds, on Bintray.

### Workflow choices

If we try to upload an artifact for a version that is already available on the repository, the API will return a 409 error. @loremattei and I discussed this, and decided to ship the first version of this automation under the assumption that all merges in `develop` and `trunk` should have a version bump.

I have a new Peril rule that [I'm working on](https://github.com/Automattic/peril-settings/pull/58) to fail a PR to a main branch that doesn't update the library's version.

## To Test

You can see that this works by comparing the [output on CI](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Utils-Android/140/workflows/e1e88b98-4c59-4061-b3be-0021e1822440/jobs/267) with the activity log in [the Bintray page](https://bintray.com/wordpress-mobile/).

CI | Bintray
--- | ---
![image](https://user-images.githubusercontent.com/1218433/99473208-38d53300-299e-11eb-886e-778291ffd1e2.png) | ![image](https://user-images.githubusercontent.com/1218433/99473143-1d6a2800-299e-11eb-87af-08fbb7ec998b.png)

I opened [this demo PR in my fork](https://github.com/mokagio/WordPress-Utils-Android/pull/10) to show that the build works when merging on `develop`, see the links in the description.

[This failed build](https://app.circleci.com/pipelines/github/mokagio/WordPress-Utils-Android/35/workflows/c85976eb-1f6e-4648-a6e4-46582b39e224) shows what happens when trying to upload an artifact for a version that already exist.

To test this for yourself, you can follow the same approach I used:

- Create your own Maven repository on Bintray
- Fork this repo
- Create a branch based off this one to your fork
- Point the Bintray plugin to your fork (see [this](https://github.com/mokagio/WordPress-Utils-Android/pull/10/commits/7d5db1505fa429e184c5ba63f89735def44182de))
- Push the branch and open a PR against your fork