### PR TITLE
Stop using url containing "video" string as video identifier

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -54,7 +54,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionName "1.30.3-beta.1"
+        versionName "1.30.3-beta.2"
         minSdkVersion 18
         targetSdkVersion 29
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -78,7 +78,7 @@ public class MediaUtils {
         url = url.toLowerCase(Locale.ROOT);
         return url.endsWith(".ogv") || url.endsWith(".mp4") || url.endsWith(".m4v") || url.endsWith(".mov")
                || url.endsWith(".wmv") || url.endsWith(".avi") || url.endsWith(".mpg") || url.endsWith(".3gp")
-               || url.endsWith(".3g2") || url.contains("video");
+               || url.endsWith(".3g2");
     }
 
     public static boolean isAudio(String url) {


### PR DESCRIPTION
The check `isVideo` is used in multiple places to find out whether an URL represents a video. Checking if the URL contains "video" string causes issues because it's not consistent. This is an issue for example in video thumbnails which are hosted on `https://videos.files.wordpress.com/` server.