### PR TITLE
Stop logging to file when no space left on device

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -54,7 +54,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionName "1.30.3-beta.2"
+        versionName "1.30.3-beta.3"
         minSdkVersion 18
         targetSdkVersion 29
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
@@ -30,7 +30,7 @@ class LogFileProvider(private val logFileDirectoryPath: String) : LogFileProvide
     override fun getLogFiles(): List<File> {
         return getLogFileDirectory()
                 .listFiles()
-                .sortedBy { it.lastModified() }
+                ?.sortedBy { it.lastModified() } ?: listOf()
     }
 
     companion object {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13271

This fix should stop logging into file when there is no more space left on the device. This is a simple fix that should catch the IOException and turn off logging once it happens. 