### PR TITLE
Adds pre & post tasks for publishing to S3

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -128,4 +128,9 @@ tasks.register('checkIfVersionIsAlreadyPublished') {
     }
 }
 
+tasks.register('successfullyPublished') {
+    println "'${getPublishVersion()}' was succesfully published."
+}
+
 publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))
+publish.finalizedBy(tasks.named('successfullyPublished'))

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -118,3 +118,14 @@ project.afterEvaluate {
     }
 }
 
+tasks.register('checkIfVersionIsAlreadyPublished') {
+    try {
+        def publishVersion = getPublishVersion()
+        new URL("https://a8c-libs.s3.amazonaws.com/android/org/wordpress/utils/${publishVersion}/utils-${publishVersion}.pom").bytes
+        throw new GradleException("'$publishVersion' is already published, please use a different version name. If this happened in CI for a PR, a new commit is necessary. If this happened for a tag, the existing version needs to be manually removed from S3.")
+    } catch (FileNotFoundException e) {
+        // Since the version doesn't already exist, proceed to publish
+    }
+}
+
+publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -119,18 +119,21 @@ project.afterEvaluate {
 }
 
 tasks.register('checkIfVersionIsAlreadyPublished') {
-    try {
-        def publishVersion = getPublishVersion()
-        new URL("https://a8c-libs.s3.amazonaws.com/android/org/wordpress/utils/${publishVersion}/utils-${publishVersion}.pom").bytes
+    def pomUrl = "https://a8c-libs.s3.amazonaws.com/android/org/wordpress/utils/${publishVersion}/utils-${publishVersion}.pom"
+    def responseCode = new URL(pomUrl).openConnection().with { connection ->
+        requestMethod = 'HEAD'
+        connect()
+        responseCode
+    }
+
+    if (responseCode == 200) {
         throw new GradleException("'$publishVersion' is already published, please use a different version name. If this happened in CI for a PR, a new commit is necessary. If this happened for a tag, the existing version needs to be manually removed from S3.")
-    } catch (FileNotFoundException e) {
-        // Since the version doesn't already exist, proceed to publish
+    } else if (responseCode == 403) {
+        // S3 returns 403 status code if a file doesn't exist, which is what we want. Proceed to publish..
+    } else {
+        throw new GradleException("An unexpected status code ($responseCode) was received while checking if the version ($publishVersion) is already published to S3. If this issue persists, please contact Platform 9 team for help.")
     }
 }
 
-tasks.register('successfullyPublished') {
-    println "'${getPublishVersion()}' was succesfully published."
-}
-
 publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))
-publish.finalizedBy(tasks.named('successfullyPublished'))
+publish.doLast { println "'$publishVersion' is succesfully published."}


### PR DESCRIPTION
This PR adds `checkIfVersionIsAlreadyPublished` gradle task which will be executed before the `publish` task. It checks if the version is already published to S3 by verifying that we get `403` as the response status code for the pom file. This way we are able to prevent overriding existing versions and provide actionable feedback to the developers if their tasks fail.

It also addresses [this feedback from the original PR](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/63#discussion_r602962459) by adding a print statement with the version name information at the end of publish task.

As a next step, I think we should pull the `checkIfVersionIsAlreadyPublished` to a custom Gradle plugin so we don't have to repeat this same code everywhere. However, considering we are short on time, I think it's best to leave this to a future PR.

**To test:**

I think it'd be enough to verify that https://github.com/wordpress-mobile/WordPress-Android/pull/14359/commits/0e396bd5c7dae7afe9fa15b59ce45e357a2b4a9f is all green in CI.