### PR TITLE
Integrates publish-to-s3 plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,5 +57,5 @@ workflows:
       - Test
       - Build and upload to S3:
           requires:
-            - Test
+            - Test 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,26 +47,19 @@ jobs:
       - run:
           name: S3 Upload
           command: |
-            # Use a different versioning style for builds from PRs to allow
-            # developers to iterate faster.
-            #
-            # If $PREFIX is not set, that is, if we're not on a PR but a merge
-            # commit on develop or trunk, the version will be the value from
-            # the source code.
-            branch=$CIRCLE_BRANCH
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              # Making the assumption that $CIRCLE_SHA1 will always be
-              # available.
-              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
-            elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
-              # This happens on the first push of a new branch, when there
-              # isn't a PR open for it yet.
-              echo "Running on a feature branch with no open PR: skipping S3 upload"
-              exit 0
+              VERSION=./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 --pull-request-url=$CIRCLE_PULL_REQUEST
+            else
+               VERSION=./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1
             fi
 
-            ./gradlew --stacktrace publish -PpublishVersion=$PREFIX
+            if [[ -z "$VERSION" ]]; then
+              echo "Running on a feature branch with no open PR: skipping S3 upload"
+              circleci-agent step halt
+            else
+              ./gradlew --stacktrace publish -PpublishVersion=$PREFIX
+            fi
+
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@dev:android-publish-to-s3
+  android: wordpress-mobile/android@dev:publish-to-s3
 
 commands:
   copy-gradle-properties:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,35 @@ commands:
       - run:
           name: Setup gradle.properties
           command: cp gradle.properties-example gradle.properties
+  calculate-s3-publish-version-name:
+    steps:
+      - run:
+          name: Calculate version name to be published to S3
+          command: |
+            PULL_REQUEST_PARAM=()
+            # Add the pull request url parameter if it exists
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              PULL_REQUEST_PARAM+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
+            fi
+
+            VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 $PULL_REQUEST_PARAM || :)
+            if [[ -z "$VERSION" ]]; then
+              echo "Running on a feature branch with no open PR: skipping S3 upload"
+              circleci-agent step halt
+            fi
+
+            echo $VERSION > /tmp/s3-publish-version
+  assert-version-is-not-already-published-to-s3:
+    steps:
+      - run:
+          name: Assert that previously calculated version is not already published to S3
+          command: |
+            VERSION=$(cat /tmp/s3-publish-version)
+            echo "Checking if '$VERSION' is already published to S3"
+            if [[ $(./gradlew checkIfVersionIsAlreadyPublished -PpublishVersion="$VERSION") ]]; then
+              echo "The following version is already published to S3 $VERSION"
+              exit 1
+            fi
 
 jobs:
   Lint:
@@ -44,17 +73,12 @@ jobs:
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache
+      - calculate-s3-publish-version-name
+      - assert-version-is-not-already-published-to-s3
       - run:
           name: S3 Upload
           command: |
-            PULL_REQUEST_PARAM=()
-            # Add the pull request url parameter if it exists
-            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-                PULL_REQUEST_PARAM+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
-            fi
-
-            VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 $PULL_REQUEST_PARAM || circleci-agent step halt)
-
+            VERSION=$(cat /tmp/s3-publish-version)
             ./gradlew --stacktrace publish -PpublishVersion=$VERSION
       - android/save-gradle-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,5 @@ workflows:
     jobs:
       - Lint
       - Test
-      - Build and upload to S3:
-          requires:
-            - Test
+      - Build and upload to S3
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
           name: S3 Upload
           command: |
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              VERSION=./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 --pull-request-url=$CIRCLE_PULL_REQUEST
+              VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 --pull-request-url=$CIRCLE_PULL_REQUEST)
             else
-               VERSION=./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1
+               VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1)
             fi
 
             if [[ -z "$VERSION" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,5 +55,7 @@ workflows:
     jobs:
       - Lint
       - Test
-      - Build and upload to S3
+      - Build and upload to S3:
+          requires:
+            - Test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,19 +47,14 @@ jobs:
       - run:
           name: S3 Upload
           command: |
+            trap 'circleci-agent step halt' ERR 
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
               VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 --pull-request-url=$CIRCLE_PULL_REQUEST)
             else
                VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1)
             fi
 
-            if [[ -z "$VERSION" ]]; then
-              echo "Running on a feature branch with no open PR: skipping S3 upload"
-              circleci-agent step halt
-            else
-              ./gradlew --stacktrace publish -PpublishVersion=$PREFIX
-            fi
-
+            ./gradlew --stacktrace publish -PpublishVersion=$PREFIX
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@0.0.22
+  android: wordpress-mobile/android@dev:publish-to-s3
 
 commands:
   copy-gradle-properties:
@@ -9,34 +9,6 @@ commands:
       - run:
           name: Setup gradle.properties
           command: cp gradle.properties-example gradle.properties
-  calculate-s3-publish-version-name:
-    steps:
-      - run:
-          name: Calculate version name to be published to S3
-          command: |
-            PULL_REQUEST_PARAM=()
-            # Add the pull request url parameter if it exists
-            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              PULL_REQUEST_PARAM+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
-            fi
-
-            VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 $PULL_REQUEST_PARAM || :)
-            if [[ -z "$VERSION" ]]; then
-              echo "Running on a feature branch with no open PR: skipping S3 upload"
-              circleci-agent step halt
-            fi
-
-            echo "$VERSION" > /tmp/s3-publish-version
-  assert-version-is-not-already-published-to-s3:
-    steps:
-      - run:
-          name: Assert that previously calculated version is not already published to S3
-          command: |
-            VERSION=$(cat /tmp/s3-publish-version)
-            if [[ $(./gradlew checkIfVersionIsAlreadyPublished -PpublishVersion="$VERSION") == "true" ]]; then
-              echo "'$VERSION' is already published to S3!"
-              exit 1
-            fi
 
 jobs:
   Lint:
@@ -72,13 +44,9 @@ jobs:
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache
-      - calculate-s3-publish-version-name
-      - assert-version-is-not-already-published-to-s3
-      - run:
-          name: S3 Upload
-          command: |
-            VERSION=$(cat /tmp/s3-publish-version)
-            ./gradlew --stacktrace publish -PpublishVersion=$VERSION
+      - android/calculate-s3-publish-version-name
+      - android/assert-version-is-not-already-published-to-s3
+      - android/publish-to-s3
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@dev:publish-to-s3
+  android: wordpress-mobile/android@dev:android-publish-to-s3
 
 commands:
   copy-gradle-properties:
@@ -44,9 +44,8 @@ jobs:
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache
-      - android/calculate-s3-publish-version-name
-      - android/assert-version-is-not-already-published-to-s3
-      - android/publish-to-s3
+      - android/publish-to-s3:
+          module_name: WordPressUtils
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,15 @@ commands:
               circleci-agent step halt
             fi
 
-            echo $VERSION > /tmp/s3-publish-version
+            echo "$VERSION" > /tmp/s3-publish-version
   assert-version-is-not-already-published-to-s3:
     steps:
       - run:
           name: Assert that previously calculated version is not already published to S3
           command: |
             VERSION=$(cat /tmp/s3-publish-version)
-            echo "Checking if '$VERSION' is already published to S3"
-            if [[ $(./gradlew checkIfVersionIsAlreadyPublished -PpublishVersion="$VERSION") ]]; then
-              echo "The following version is already published to S3 $VERSION"
+            if [[ $(./gradlew checkIfVersionIsAlreadyPublished -PpublishVersion="$VERSION") == "true" ]]; then
+              echo "'$VERSION' is already published to S3!"
               exit 1
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,15 @@ jobs:
       - run:
           name: S3 Upload
           command: |
-            trap 'circleci-agent step halt' ERR 
+            PULL_REQUEST_PARAM=()
+            # Add the pull request url parameter if it exists
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 --pull-request-url=$CIRCLE_PULL_REQUEST)
-            else
-               VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1)
+                PULL_REQUEST_PARAM+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
             fi
 
-            ./gradlew --stacktrace publish -PpublishVersion=$PREFIX
+            VERSION=$(./gradlew -q calculateVersionName --branch-name=$CIRCLE_BRANCH --sha1=$CIRCLE_SHA1 $PULL_REQUEST_PARAM || circleci-agent step halt)
+
+            ./gradlew --stacktrace publish -PpublishVersion=$VERSION
       - android/save-gradle-cache
 
 workflows:

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.2'
+        classpath 'com.automattic.android:publish-to-s3:0.2.1'
     }
 }
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -86,6 +86,10 @@ android.libraryVariants.all { variant ->
     }
 }
 
+def getPublishVersion() {
+  return project.properties['publishVersion'] ?: android.defaultConfig.versionName
+}
+
 // Because the components are created only during the `afterEvaluate` phase, we
 // must configure our publications using the `afterEvaluate()` lifecycle method
 //
@@ -97,8 +101,8 @@ project.afterEvaluate {
                 // Applies the component for the release build variant
                 from components.release
 
-                groupId getGroupId()
-                artifactId getArtifactId()
+                groupId 'org.wordpress'
+                artifactId 'utils'
                 version getPublishVersion()
             }
         }
@@ -115,23 +119,11 @@ project.afterEvaluate {
 }
 
 tasks.register('checkIfVersionIsAlreadyPublished', com.automattic.android.publish.CheckS3VersionTask) {
-    publishedGroupId = getGroupId()
-    moduleName = getArtifactId()
+    publishedGroupId = 'org.wordpress'
+    moduleName = 'utils'
     versionName = getPublishVersion()
 }
 
 publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))
 publish.doLast { println "'$publishVersion' is succesfully published."}
-
-def getGroupId() {
-    return "org.wordpress"
-}
-
-def getArtifactId() {
-    return "utils"
-}
-
-def getPublishVersion() {
-  return project.properties['publishVersion'] ?: android.defaultConfig.versionName
-}
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -5,9 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android'
-        }
+        maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
@@ -90,7 +88,7 @@ android.libraryVariants.all { variant ->
     }
 }
 
-configureS3PublishPlugin {
+s3PublishPlugin {
     groupId = "org.wordpress"
     artifactId = "utils"
     from = "release"

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -86,10 +86,6 @@ android.libraryVariants.all { variant ->
     }
 }
 
-def getPublishVersion() {
-  return project.properties['publishVersion'] ?: android.defaultConfig.versionName
-}
-
 // Because the components are created only during the `afterEvaluate` phase, we
 // must configure our publications using the `afterEvaluate()` lifecycle method
 //
@@ -101,8 +97,8 @@ project.afterEvaluate {
                 // Applies the component for the release build variant
                 from components.release
 
-                groupId 'org.wordpress'
-                artifactId 'utils'
+                groupId getGroupId()
+                artifactId getArtifactId()
                 version getPublishVersion()
             }
         }
@@ -118,22 +114,24 @@ project.afterEvaluate {
     }
 }
 
-tasks.register('checkIfVersionIsAlreadyPublished') {
-    def pomUrl = "https://a8c-libs.s3.amazonaws.com/android/org/wordpress/utils/${publishVersion}/utils-${publishVersion}.pom"
-    def responseCode = new URL(pomUrl).openConnection().with { connection ->
-        requestMethod = 'HEAD'
-        connect()
-        responseCode
-    }
-
-    if (responseCode == 200) {
-        throw new GradleException("'$publishVersion' is already published, please use a different version name. If this happened in CI for a PR, a new commit is necessary. If this happened for a tag, the existing version needs to be manually removed from S3.")
-    } else if (responseCode == 403) {
-        // S3 returns 403 status code if a file doesn't exist, which is what we want. Proceed to publish..
-    } else {
-        throw new GradleException("An unexpected status code ($responseCode) was received while checking if the version ($publishVersion) is already published to S3. If this issue persists, please contact Platform 9 team for help.")
-    }
+tasks.register('checkIfVersionIsAlreadyPublished', com.automattic.android.publish.CheckS3VersionTask) {
+    publishedGroupId = getGroupId()
+    moduleName = getArtifactId()
+    versionName = getPublishVersion()
 }
 
 publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))
 publish.doLast { println "'$publishVersion' is succesfully published."}
+
+def getGroupId() {
+    return "org.wordpress"
+}
+
+def getArtifactId() {
+    return "utils"
+}
+
+def getPublishVersion() {
+  return project.properties['publishVersion'] ?: android.defaultConfig.versionName
+}
+

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.1'
+        classpath 'com.automattic.android:publish-to-s3:0.2'
     }
 }
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -89,8 +89,8 @@ android.libraryVariants.all { variant ->
 }
 
 s3PublishPlugin {
-    groupId = "org.wordpress"
-    artifactId = "utils"
-    from = "release"
+    groupId "org.wordpress"
+    artifactId "utils"
+    from "release"
 }
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -5,17 +5,21 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.automattic.android:publish-to-s3:0.1'
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven-publish'
+apply plugin: 'com.automattic.android.publish-to-s3'
 
 repositories {
     google()
@@ -86,44 +90,9 @@ android.libraryVariants.all { variant ->
     }
 }
 
-def getPublishVersion() {
-  return project.properties['publishVersion'] ?: android.defaultConfig.versionName
+configureS3PublishPlugin {
+    groupId = "org.wordpress"
+    artifactId = "utils"
+    from = "release"
 }
-
-// Because the components are created only during the `afterEvaluate` phase, we
-// must configure our publications using the `afterEvaluate()` lifecycle method
-//
-// See https://developer.android.com/studio/build/maven-publish-plugin
-project.afterEvaluate {
-    publishing {
-        publications {
-            UtilsPublication(MavenPublication) {
-                // Applies the component for the release build variant
-                from components.release
-
-                groupId 'org.wordpress'
-                artifactId 'utils'
-                version getPublishVersion()
-            }
-        }
-        repositories {
-            maven {
-                url "s3://a8c-libs.s3.amazonaws.com/android"
-                credentials(AwsCredentials) {
-                    accessKey project.hasProperty('awsAccessKey') ? project.properties['awsAccessKey'] : System.getenv('AWS_ACCESS_KEY')
-                    secretKey project.hasProperty('awsSecretKey') ? project.properties['awsSecretKey'] : System.getenv('AWS_SECRET_KEY')
-                }
-            }
-        }
-    }
-}
-
-tasks.register('checkIfVersionIsAlreadyPublished', com.automattic.android.publish.CheckS3VersionTask) {
-    publishedGroupId = 'org.wordpress'
-    moduleName = 'utils'
-    versionName = getPublishVersion()
-}
-
-publish.dependsOn(tasks.named('checkIfVersionIsAlreadyPublished'))
-publish.doLast { println "'$publishVersion' is succesfully published."}
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,19 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+        }
     }
 
     dependencies {
         classpath 'com.automattic.android:fetchstyle:1.1'
+        classpath 'com.automattic.android:publish-to-s3:0.1'
     }
 }
 
 apply plugin: 'com.automattic.android.fetchstyle'
+apply plugin: 'com.automattic.android.publish-to-s3'
 
 allprojects {
     apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,14 @@
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android'
-        }
     }
 
     dependencies {
         classpath 'com.automattic.android:fetchstyle:1.1'
-        classpath 'com.automattic.android:publish-to-s3:0.1'
     }
 }
 
 apply plugin: 'com.automattic.android.fetchstyle'
-apply plugin: 'com.automattic.android.publish-to-s3'
 
 allprojects {
     apply plugin: 'checkstyle'


### PR DESCRIPTION
This PR integrates [publish-to-s3-gradle-plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) and utilizes [the new `publish-to-s3` command from our android orb](https://github.com/wordpress-mobile/circleci-orbs/pull/72).

**To test:**

* Create a new PR from this branch and push a dummy commit. You may also need to open a draft PR if the `Build and upload to S3` workflow is not run.
* Update WPAndroid's [wordPressUtilsVersion](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/build.gradle#L8) to the newly published version and verify that it builds and runs.

Note that we'll need to publish a new version of our orbs and update the orb version in this PR, but since this PR is targeting a WIP branch, it's OK to merge it even if a new version is not published yet.