### PR TITLE
Enable tags and disable random branch artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       name: android/default
       api-version: "27"
     steps:
-      - android/should-publish-library-artifacts
+      - android/check-precondition-for-publish-artifacts
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,10 @@ workflows:
   WordPress-Utils-Android:
     jobs:
       - Lint
-      - Test
+      - Test:
+          filters:
+            tags:
+              only: /.*/
       - Build and upload to S3:
           requires:
             - Test 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ jobs:
       - android/save-gradle-cache
 
 workflows:
-  # We don't want this to run on tags, but no filter statement is necessary
-  # because that's the default behavior
   WordPress-Utils-Android:
     jobs:
       - Lint
@@ -59,4 +57,7 @@ workflows:
       - Build and upload to S3:
           requires:
             - Test 
+          filters:
+            tags:
+              only: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@dev:should-publish-library-artifacts
+  android: wordpress-mobile/android@1.0.20
 
 commands:
   copy-gradle-properties:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@dev:publish-to-s3
+  android: wordpress-mobile/android@dev:should-publish-library-artifacts
 
 commands:
   copy-gradle-properties:
@@ -41,6 +41,7 @@ jobs:
       name: android/default
       api-version: "27"
     steps:
+      - android/should-publish-library-artifacts
       - checkout
       - copy-gradle-properties
       - android/restore-gradle-cache

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.2.1'
+        classpath 'com.automattic.android:publish-to-s3:0.2.2'
     }
 }
 


### PR DESCRIPTION
This PR updates `publish-to-s3-gradle-plugin` to `0.2.2` which includes [this fix](https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/4). It also utilizes the `should-publish-library-artifacts` command from [this PR](https://github.com/wordpress-mobile/circleci-orbs/pull/73). @jkmassel Since `only build pull requests` option didn't do exactly what we wanted, I disabled that and introduced this command instead. Let me know what you think!

This PR is also supposed to enable publishing artifacts from all tags, but I couldn't get it to work. @jkmassel @mokagio Maybe you can help me with that?

This is probably the last PR before we merge everything to `develop` and update the clients. I am also planning to post an announcement for it. Let me know if I am missing anything!