### PR TITLE
Remove versionName field from utils build.gradle

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -54,7 +54,6 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionName "1.30.3-beta.3"
         minSdkVersion 18
         targetSdkVersion 29
 


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/76#issuecomment-832461981 .

I agree with @oguzkocer's comment linked above, and the tag based release flow for the library is something that makes sense to me. I like the single source of truth, even though it feels odd not to have the version value in the codebase, like Ruby gems and Node modules do, for example.

I am not a consumer or a developer of this library, though, so I'm not sure whether what makes sense for me in theory is actually useful in practice. I remember chatting with Lorenzo about the release process for this library in the past and realizing it didn't match my expectation 🤔 , and that there was a rationale for it 🤷‍♂️ . That's why I have left this as a draft for now.