### PR TITLE
Update publish-to-s3 plugin to 0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@1.0.20
+  android: wordpress-mobile/android@dev:refactor-publish-to-s3-to-accept-gradle-task-param
 
 commands:
   copy-gradle-properties:
@@ -46,7 +46,7 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - android/publish-to-s3:
-          module_name: WordPressUtils
+          publish_gradle_task: :WordPressUtils:publishLibraryToS3
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: wordpress-mobile/android@dev:refactor-publish-to-s3-to-accept-gradle-task-param
+  android: wordpress-mobile/android@1.0.21
 
 commands:
   copy-gradle-properties:

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,14 +10,14 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.2.2'
+        classpath 'com.automattic.android:publish-to-s3:0.3'
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'com.automattic.android.publish-to-s3'
+apply plugin: 'com.automattic.android.publish-library-to-s3'
 
 repositories {
     google()
@@ -87,7 +87,7 @@ android.libraryVariants.all { variant ->
     }
 }
 
-s3PublishPlugin {
+s3PublishLibrary {
     groupId "org.wordpress"
     artifactId "utils"
     from "release"

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.3'
+        classpath 'com.automattic.android:publish-to-s3:0.3.1'
     }
 }
 


### PR DESCRIPTION
There are a few minor changes in the plugin, but they should be obvious from the code changes. The orb also changed and we now pass the full gradle command instead of just the module name.

**To test:**
As long as CI succeeds, I think we should be good to merge this. For the paranoid, the new version can be used in WPAndroid to make sure it builds successfully. (I'll do that later today)