### PR TITLE
Update publish-to-s3 plugin to 0.4.0

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:publish-to-s3:0.3.1'
+        classpath 'com.automattic.android:publish-to-s3:0.4.0'
     }
 }
 


### PR DESCRIPTION
This change has been tried by @mzorz and @antonis in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/80, so as long as CI is happy, we are good to merge it.