### PR TITLE
Update README for 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.wordpress:utils:1.40.0'
+    implementation 'org.wordpress:utils:1.5.0'
 }
 ```
 
@@ -21,7 +21,6 @@ In the following cases, CircleCI will publish a new version with the following f
 
 * For each commit in an open PR: `<PR-number>-<commit full SHA1>`
 * Each time a PR is merged to `develop`: `develop-<commit full SHA1>`
-* Each time a PR is merged to `trunk`: `trunk-<commit full SHA1>`
 * Each time a new tag is created: `{tag-name}`
 
 ## Apps and libraries using WordPress-Utils-Android:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.wordpress:utils:1.5.0'
+    implementation 'org.wordpress:utils:2.0.0'
 }
 ```
 


### PR DESCRIPTION
I've enabled [only build pull requests feature on CircleCI](https://circleci.com/docs/2.0/oss/#only-build-pull-requests) for this repo, which means `trunk` is currently not being built. I've removed this from README and updated the version to `1.5.0` while I was modifying the file.

Please note that I've created the new version as `1.5.0` instead of `1.50.0` to be more consistent with rest of the libraries. I hope that won't cause any issues.