### PR TITLE
Moves over VersionUtils from WordPress-Android

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/VersionUtils.kt
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/VersionUtils.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.helpers.Version
+
+object VersionUtils {
+    /**
+     * Checks if a given version [String] is equal to or higher than another given minimal version [String].
+     *
+     * Note: This method ignores "-beta", "-alpha" or "-RC" versions, meaning that this will return `true` for
+     * a version "5.5-beta1" and `minVersion` "5.5", for example.
+     *
+     * @param version The version [String] to check.
+     * @param minVersion A minimal acceptable version [String].
+     * @return `true` if the version is equal to or higher than the `minVersion`; `false` otherwise.
+     */
+    @JvmStatic fun checkMinimalVersion(version: String?, minVersion: String?) =
+            if (!version.isNullOrEmpty() && !minVersion.isNullOrEmpty()) {
+                try {
+                    Version(stripVersionSuffixes(version)) >= Version(stripVersionSuffixes(minVersion))
+                } catch (e: IllegalArgumentException) {
+                    AppLog.e(UTILS, "Invalid version $version, expected $minVersion", e)
+                    false
+                }
+            } else false
+
+    // Strip any trailing "-beta", "-alpha" or "-RC" suffixes from the version
+    private fun stripVersionSuffixes(version: String) = version.substringBefore("-")
+}

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/VersionUtilsTest.kt
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/VersionUtilsTest.kt
@@ -1,0 +1,159 @@
+package org.wordpress.android.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class VersionUtilsTest {
+    @Test
+    fun `checkMinimalVersion returns true when the major part of the version is higher than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "6.0",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion returns true when the minor part of the version is higher than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.6",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion returns true when the patch part of the version is higher than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5.1",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion returns true when the version is equal to the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the major part of the version is lower than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "4.0",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the minor part of the version is lower than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.4",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the patch part of the version is lower than the minimal version`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5",
+                minVersion = "5.5.1"
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores suffixes on the version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5-beta1",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores suffixes on the minimal version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5-beta1",
+                minVersion = "5.5-beta2"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores double suffixes on the version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5-alpha-51379",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores double suffixes on the minimal version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5-alpha-51370",
+                minVersion = "5.5-alpha-51380"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores zero on the patch part of the version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5.0",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion ignores zero on the patch part of the minimal version string`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5",
+                minVersion = "5.5.0"
+        )
+        assertThat(hasMinimalVersion).isTrue
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the version string is null`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = null,
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the version string is empty`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "",
+                minVersion = "5.5"
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the minimal version string is null`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5",
+                minVersion = null
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+
+    @Test
+    fun `checkMinimalVersion returns false when the minimal version string is empty`() {
+        val hasMinimalVersion = VersionUtils.checkMinimalVersion(
+                version = "5.5",
+                minVersion = ""
+        )
+        assertThat(hasMinimalVersion).isFalse
+    }
+}


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15287

### Description
Moves [`VersionUtils`](https://github.com/wordpress-mobile/WordPress-Android/blob/feeacbc8ac15a903608ee0fc7671e03d2e10a014/WordPress/src/main/java/org/wordpress/android/util/VersionUtils.kt) from `WordPress-Android` to `WordPress-Utils-Android` in order to be available in the `WordPress-FluxC-Android` project