### PR TITLE
Upload lint & checkstyle artifacts to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,7 @@ steps:
       ./gradlew lint checkstyle
     artifact_paths:
       - "**/build/reports/lint-results.*"
+      - "**/build/reports/checkstyle/checkstyle.*"
 
   - label: "Test"
     key: "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,8 @@ steps:
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew lint checkstyle
+    artifact_paths:
+      - "**/build/reports/lint-results.*"
 
   - label: "Test"
     key: "test"


### PR DESCRIPTION
Adds support for uploading lint & checkstyle artifacts to Buildkite, so developers can access it especially when there is an error.

**To test**
* Go to Buildkite job and check the artifacts tab for `Lint & Checkstyle` job and verify the artifacts uploaded.
* For https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/97, go to Buildkite job and check the artifacts tab for `Lint & Checkstyle` job - Notice that even if the Gradle task fails, the artifact is still uploaded.