### PR TITLE
Publish sources jar to S3

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -58,11 +58,6 @@ android {
     }
 }
 
-tasks.register("sourcesJar", Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "sources"
-}
-
 project.afterEvaluate {
     publishing {
         publications {
@@ -71,7 +66,7 @@ project.afterEvaluate {
 
                 groupId "org.wordpress"
                 artifactId "utils"
-                artifact tasks.named("sourcesJar")
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -73,8 +73,3 @@ project.afterEvaluate {
    }
 }
 
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress"
-    mavenPublishArtifactId "utils"
-}
-

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -58,6 +58,11 @@ android {
     }
 }
 
+tasks.register("sourcesJar", Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier "sources"
+}
+
 project.afterEvaluate {
     publishing {
         publications {
@@ -66,6 +71,7 @@ project.afterEvaluate {
 
                 groupId "org.wordpress"
                 artifactId "utils"
+                artifact tasks.named("sourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR updates `publish-to-s3` Gradle plugin to `0.7.0` and uses the newly introduced `androidSourcesJar` task to upload the `-sources.jar` file so it can be used by developers to access the source code from their IDEs. More details can be found in: https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29

**To test:**
* Follow the test instructions in https://github.com/wordpress-mobile/WordPress-Android/pull/15492