### PR TITLE
Display size calculation fixes

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -11,6 +11,8 @@ import android.view.Display;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.annotation.NonNull;
+
 public class DisplayUtils {
     private DisplayUtils() {
         throw new AssertionError();
@@ -39,11 +41,21 @@ public class DisplayUtils {
         return getWindowSize(context).height();
     }
 
-    public static int getWindowPixelWidth(Context context) {
+    /**
+     * Calculates the width of the application's window
+     * @param context
+     * @return the width of the window
+     */
+    public static int getWindowPixelWidth(@NonNull Context context) {
         return getWindowSize(context).width();
     }
 
-    public static int getWindowPixelHeight(Context context) {
+    /**
+     * Calculates the height of the application's window
+     * @param context
+     * @return the height of the window
+     */
+    public static int getWindowPixelHeight(@NonNull Context context) {
         return getWindowSize(context).height();
     }
 
@@ -59,6 +71,9 @@ public class DisplayUtils {
         }
     }
 
+    /**
+     * @return the width of the device's screen
+     */
     public static int getDisplayPixelWidth() {
         return Resources.getSystem().getDisplayMetrics().widthPixels;
     }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.util;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
 import android.util.DisplayMetrics;
@@ -25,6 +26,22 @@ public class DisplayUtils {
         return context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
     }
 
+    /**
+     * Calculates the size of the application's window
+     * @param context
+     * @return Point with the window's dimenstions
+     * 
+     * @deprecated please use {@link #getWindowSize(Context)}
+     */
+    @Deprecated
+    public static Point getDisplayPixelSize(Context context) {
+        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+        return size;
+    }
+    
     /**
      * @deprecated please use {@link #getWindowPixelWidth(Context)} instead
      */
@@ -59,7 +76,7 @@ public class DisplayUtils {
         return getWindowSize(context).height();
     }
 
-    private static Rect getWindowSize(Context context) {
+    public static Rect getWindowSize(Context context) {
         WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             return wm.getCurrentWindowMetrics().getBounds();

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -3,7 +3,8 @@ package org.wordpress.android.util;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.graphics.Point;
+import android.graphics.Rect;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Display;
@@ -22,22 +23,40 @@ public class DisplayUtils {
         return context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
     }
 
-    public static Point getDisplayPixelSize(Context context) {
-        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = wm.getDefaultDisplay();
-        Point size = new Point();
-        display.getSize(size);
-        return size;
-    }
-
+    /**
+     * @deprecated please use {@link #getWindowPixelWidth(Context)} instead
+     */
+    @Deprecated
     public static int getDisplayPixelWidth(Context context) {
-        Point size = getDisplayPixelSize(context);
-        return (size.x);
+        return getWindowSize(context).width();
     }
 
+    /**
+     * @deprecated please use {@link #getWindowPixelHeight(Context)} instead
+     */
+    @Deprecated
     public static int getDisplayPixelHeight(Context context) {
-        Point size = getDisplayPixelSize(context);
-        return (size.y);
+        return getWindowSize(context).height();
+    }
+
+    public static int getWindowPixelWidth(Context context) {
+        return getWindowSize(context).width();
+    }
+
+    public static int getWindowPixelHeight(Context context) {
+        return getWindowSize(context).height();
+    }
+
+    private static Rect getWindowSize(Context context) {
+        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return wm.getCurrentWindowMetrics().getBounds();
+        } else {
+            Display display = wm.getDefaultDisplay();
+            Rect rect = new Rect();
+            display.getRectSize(rect);
+            return rect;
+        }
     }
 
     public static int getDisplayPixelWidth() {

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -755,7 +755,7 @@ public class ImageUtils {
         int maximumThumbnailWidthForEditor;
         int screenWidth = DisplayUtils.getWindowPixelWidth(context);
         int screenHeight = DisplayUtils.getWindowPixelHeight(context);
-        maximumThumbnailWidthForEditor = (screenWidth > screenHeight) ? screenHeight : screenWidth;
+        maximumThumbnailWidthForEditor = Math.min(screenWidth, screenHeight);
         // 48dp of padding on each side so you can still place the cursor next to the image.
         int padding = DisplayUtils.dpToPx(context, 48) * 2;
         maximumThumbnailWidthForEditor -= padding;

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -9,7 +9,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
-import android.graphics.Point;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
@@ -754,9 +753,8 @@ public class ImageUtils {
      */
     public static int getMaximumThumbnailWidthForEditor(Context context) {
         int maximumThumbnailWidthForEditor;
-        Point size = DisplayUtils.getDisplayPixelSize(context);
-        int screenWidth = size.x;
-        int screenHeight = size.y;
+        int screenWidth = DisplayUtils.getWindowPixelWidth(context);
+        int screenHeight = DisplayUtils.getWindowPixelHeight(context);
         maximumThumbnailWidthForEditor = (screenWidth > screenHeight) ? screenHeight : screenWidth;
         // 48dp of padding on each side so you can still place the cursor next to the image.
         int padding = DisplayUtils.dpToPx(context, 48) * 2;


### PR DESCRIPTION
The DisplayUtils is using deprecated functions for calculating the display size, since Android 11, the Android team introduced the notion of WindowMetrics to account for the aspect of resizability of windows in Android in the future, this new API should offer more accurate results, and allow taking the insets (system bars) into account when calculating it.

The change I did here uses the default value returned by `getCurrentWindowMetrics` without excluding the insets, as it's same as what `getDefaultDisplay` is giving, in the future, we can decide if we want to update it.

I also included another change, the API currently has two methods called `getDisplayPixelWidth`, one of them needs a Context, and the other one doesn't, but the real issue is that they give different results when the screen is split, since one will return the actual size of the display, while the one accepting `Context` will return the size of the app's window, so I renamed the functions a bit to make it clear to `getWindowPixelWidth` and `getWindowPixelHeight`.
I deprecated the other ones to avoid breaking anything, but I wonder if this is the right move, or should we remove them and update the clients right away, WDYT?

For testing, please refer to the PR https://github.com/woocommerce/woocommerce-android/pull/5346