### PR TITLE
Updates 'develop' reference in README to 'trunk'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dependencies {
 
 ## Publishing a new version
 
-In the following cases, CircleCI will publish a new version with the following format to our remote Maven repo:
+In the following cases, the CI will publish a new version with the following format to our remote Maven repo:
 
 * For each commit in an open PR: `<PR-number>-<commit full SHA1>`
 * Each time a PR is merged to `trunk`: `trunk-<commit full SHA1>`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies {
 In the following cases, CircleCI will publish a new version with the following format to our remote Maven repo:
 
 * For each commit in an open PR: `<PR-number>-<commit full SHA1>`
-* Each time a PR is merged to `develop`: `develop-<commit full SHA1>`
+* Each time a PR is merged to `trunk`: `trunk-<commit full SHA1>`
 * Each time a new tag is created: `{tag-name}`
 
 ## Apps and libraries using WordPress-Utils-Android:


### PR DESCRIPTION
We have renamed the default branch to `trunk`. This PR updates the README to reflect that change.