### PR TITLE
Update events but to v3.3.1 which is migrated to AndroidX

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'org.greenrobot:eventbus:3.0.0'
+    implementation 'org.greenrobot:eventbus:3.3.1'
 
     implementation "androidx.core:core-ktx:$kotlin_ktx_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"


### PR DESCRIPTION
This PR updates event bus to v3.3.1 that supports AndroidX.