### PR TITLE
Add My Site Dashboard Tag to AppLog

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,8 +18,8 @@ steps:
       cp gradle.properties-example gradle.properties
       ./gradlew lint checkstyle
     artifact_paths:
-      - "**/build/reports/lint-results.*"
-      - "**/build/reports/checkstyle/checkstyle.*"
+#      - "**/build/reports/lint-results.*"
+#      - "**/build/reports/checkstyle/checkstyle.*"
 
   - label: "Test"
     key: "test"

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -64,7 +64,8 @@ public class AppLog {
         SITE_CREATION,
         DOMAIN_REGISTRATION,
         FEATURE_ANNOUNCEMENT,
-        PREPUBLISHING_NUDGES
+        PREPUBLISHING_NUDGES,
+        MY_SITE_DASHBOARD
     }
 
     public static final String TAG = "WordPress";


### PR DESCRIPTION
This PR adds `MY_SITE_DASHBOARD` tag to AppLog.

Note: As discussed in p1645167034584119-slack-CC7L49W13, I commented `artifact_paths` to unblock us from merging the PR to `trunk`.