### PR TITLE
Re-enable lint & checkstyle artifact uploads from Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,8 +18,8 @@ steps:
       cp gradle.properties-example gradle.properties
       ./gradlew lint checkstyle
     artifact_paths:
-#      - "**/build/reports/lint-results.*"
-#      - "**/build/reports/checkstyle/checkstyle.*"
+      - "**/build/reports/lint-results.*"
+      - "**/build/reports/checkstyle/checkstyle.*"
 
   - label: "Test"
     key: "test"


### PR DESCRIPTION
The artifact uploads were disabled in #103 due to a permission issue in our AWS instances. This PR re-enables them.