### PR TITLE
Removes Deprecated Display functions

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -3,7 +3,6 @@ package org.wordpress.android.util;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
 import android.util.DisplayMetrics;

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -27,38 +27,6 @@ public class DisplayUtils {
     }
 
     /**
-     * Calculates the size of the application's window
-     * @param context
-     * @return Point with the window's dimenstions
-     * 
-     * @deprecated please use {@link #getWindowSize(Context)}
-     */
-    @Deprecated
-    public static Point getDisplayPixelSize(Context context) {
-        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = wm.getDefaultDisplay();
-        Point size = new Point();
-        display.getSize(size);
-        return size;
-    }
-    
-    /**
-     * @deprecated please use {@link #getWindowPixelWidth(Context)} instead
-     */
-    @Deprecated
-    public static int getDisplayPixelWidth(Context context) {
-        return getWindowSize(context).width();
-    }
-
-    /**
-     * @deprecated please use {@link #getWindowPixelHeight(Context)} instead
-     */
-    @Deprecated
-    public static int getDisplayPixelHeight(Context context) {
-        return getWindowSize(context).height();
-    }
-
-    /**
      * Calculates the width of the application's window
      * @param context
      * @return the width of the window


### PR DESCRIPTION
This PR removes the deprecated functions from the Library.

### Context
The Display functions for getting the size of the Display were deprecated in the Android 11 and Instead, the Window metrics were introduced for replacing them. 

- As part of the Migration to Android 12 the window metrics APIs were added to the Utils library in this [PR](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/99)
- The usages of the deprecated display functions were removed from the WooCommerce Android repo in this [PR](https://github.com/woocommerce/woocommerce-android/pull/5346)
- The usages of the deprecated display functions were removed from the Wordpress Android  repo in this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16677) 

 Testing Instructions 
- Make sure that only deprecated functions were removed. 
