### PR TITLE
Updates: compile sdk version and target sdk version to 31 for Android 12 migration 

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -26,12 +26,12 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation "org.robolectric:robolectric:4.4"
-    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation 'androidx.test:core:1.4.0'
 
     lintChecks 'org.wordpress:lint:1.1.0'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
 
 }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -100,7 +100,7 @@ public class ImageUtils {
                             .query(curStream, new String[]{MediaStore.Images.Media.ORIENTATION}, null, null, null);
             if (cur != null) {
                 if (cur.moveToFirst()) {
-                    orientation = cur.getInt(cur.getColumnIndex(MediaStore.Images.Media.ORIENTATION));
+                    orientation = cur.getInt(cur.getColumnIndexOrThrow(MediaStore.Images.Media.ORIENTATION));
                 }
                 cur.close();
             }


### PR DESCRIPTION
Closes #109

This PR updates the target SDK version to 31 for the Android 12 migration

Test Instructions
- Install the app from the Parent PR
- Make sure the functionalities provided by the library work as expected
