### PR TITLE
Update `minSdkVersion` (from `21` to `24`)

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion gradle.ext.compileSdkVersion
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion gradle.ext.minSdkVersion
-        targetSdkVersion gradle.ext.targetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 31
+    compileSdkVersion gradle.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdkVersion gradle.ext.minSdkVersion
+        targetSdkVersion gradle.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,3 +18,9 @@ allprojects {
         }
     }
 }
+
+ext {
+    minSdkVersion = 24
+    compileSdkVersion = 31
+    targetSdkVersion = 31
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ pluginManagement {
 include ':WordPressUtils'
 
 gradle.ext {
-    minSdkVersion = 21
+    minSdkVersion = 24
     compileSdkVersion = 31
     targetSdkVersion = 31
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,4 +27,11 @@ pluginManagement {
         }
     }
 }
+
 include ':WordPressUtils'
+
+gradle.ext {
+    minSdkVersion = 21
+    compileSdkVersion = 31
+    targetSdkVersion = 31
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,9 +29,3 @@ pluginManagement {
 }
 
 include ':WordPressUtils'
-
-gradle.ext {
-    minSdkVersion = 24
-    compileSdkVersion = 31
-    targetSdkVersion = 31
-}


### PR DESCRIPTION
This PR upgrades Utils to `minSdkVersion` to `24`. This has been unblocked because:

- `WPAndroid` was already on `minSdkVersion = 24`, for some time now (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15135)).
- `WCAndroid` has been recently upgraded to `minSdkVersion = 24` as well (see [here](https://github.com/woocommerce/woocommerce-android/pull/7643)).

-----

PS: @JorgeMucientes @irfano I added you as the main reviewers, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from both, the `WordPress` and `Woo Commerce` teams, to sign-off on that change for WPAndroid and WCAndroid alike.

-----

### Testing instructions

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test, either the `WordPress` or `Woo Commerce` apps, with this version of `Utils`, and see if it works as expected.
    - Try and install, either the `WordPress` or `Woo Commerce` apps, with this version of `Utils`, on Android 5 (`API 21/22`) and Android 6 (`API 23`) devices and verify that you can't (see [API Levels](https://apilevels.com/)).