### PR TITLE
Update Kotlin to 1.6.10

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -11,26 +11,26 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.commons:commons-text:1.1'
-    implementation 'com.android.volley:volley:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'org.greenrobot:eventbus:3.3.1'
+    implementation "org.apache.commons:commons-text:$commonsTextVersion"
+    implementation "com.android.volley:volley:$volleyVersion"
+    implementation "com.google.android.material:material:$materialVersion"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeRefreshLayoutVersion"
+    implementation "androidx.recyclerview:recyclerview:$androidxRecyclerViewVersion"
+    implementation "org.greenrobot:eventbus:$eventBusVersion"
 
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation "org.robolectric:robolectric:4.9"
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 
-    lintChecks 'org.wordpress:lint:1.1.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+    lintChecks "org.wordpress:lint:$wordpressLintVersion"
+    androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
+    androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
+    androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
+    androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
 
 }
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id "com.automattic.android.publish-to-s3"
 }
 
-ext.kotlin_ktx_version = '1.5.0'
-
 repositories {
     google()
     mavenCentral()
@@ -20,7 +18,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'org.greenrobot:eventbus:3.3.1'
 
-    implementation "androidx.core:core-ktx:$kotlin_ktx_version"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
 
     testImplementation 'junit:junit:4.12'

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation "org.robolectric:robolectric:4.4"
+    testImplementation "org.robolectric:robolectric:4.9"
     testImplementation 'androidx.test:core:1.4.0'
 
     lintChecks 'org.wordpress:lint:1.1.0'

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,7 +36,7 @@ class LogFileCleanerTest {
             file.setLastModified(it * 10_000L)
         }
 
-        assert(testProvider.getLogFileDirectory().listFiles().count() == MAX_FILES)
+        assert(testProvider.getLogFileDirectory().listFiles()?.count() == MAX_FILES)
     }
 
     @After
@@ -62,12 +63,12 @@ class LogFileCleanerTest {
     fun testThatCleanerPreservesCorrectNumberOfFiles() {
         val numberOfFiles = Random.nextInt(MAX_FILES)
         LogFileCleaner(testProvider, numberOfFiles).clean()
-        assertEquals(numberOfFiles, testProvider.getLogFileDirectory().listFiles().count())
+        assertEquals(numberOfFiles, testProvider.getLogFileDirectory().listFiles()?.count())
     }
 
     @Test
     fun testThatCleanerErasesAllFilesIfGivenZero() {
         LogFileCleaner(testProvider, 0).clean()
-        assert(testProvider.getLogFileDirectory().listFiles().isEmpty())
+        assertTrue(testProvider.getLogFileDirectory().listFiles()?.isEmpty() ?: false)
     }
 }

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
@@ -3,9 +3,6 @@ package org.wordpress.android.util
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
-import java.io.File
-import java.io.FileReader
-import kotlin.random.Random
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -15,6 +12,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.util.helpers.logfile.LogFileCleaner
 import org.wordpress.android.util.helpers.logfile.LogFileProvider
+import java.io.File
+import java.io.FileReader
+import kotlin.random.Random
 
 /**
  *  The number of test files to create for each test run
@@ -24,35 +24,33 @@ private const val MAX_FILES = 10
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileCleanerTest {
-    private lateinit var logFileProvider: LogFileProvider
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val testProvider = LogFileProvider.fromContext(context)
 
     @Before
     fun setup() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        logFileProvider = LogFileProvider.fromContext(context)
-
         repeat(MAX_FILES) {
-            val file = File(logFileProvider.getLogFileDirectory(), "$it.log")
+            val file = File(testProvider.getLogFileDirectory(), "$it.log")
             file.writeText("$it")
             file.setLastModified(it * 10_000L)
         }
 
-        assert(logFileProvider.getLogFileDirectory().listFiles().count() == MAX_FILES)
+        assert(testProvider.getLogFileDirectory().listFiles().count() == MAX_FILES)
     }
 
     @After
     fun tearDown() {
         // Delete the test directory after each test
-        logFileProvider.getLogFileDirectory().deleteRecursively()
+        testProvider.getLogFileDirectory().deleteRecursively()
     }
 
     @Test
     fun testThatCleanerPreservesMostRecentlyCreatedFiles() {
         val maxLogFileCount = Random.nextInt(MAX_FILES)
-        LogFileCleaner(logFileProvider, maxLogFileCount).clean()
+        LogFileCleaner(testProvider, maxLogFileCount).clean()
 
         // Strings are easier to assert against than arrays
-        val remainingFileIds = logFileProvider.getLogFiles().joinToString(",") {
+        val remainingFileIds = testProvider.getLogFiles().joinToString(",") {
             FileReader(it).readText()
         }
 
@@ -63,13 +61,13 @@ class LogFileCleanerTest {
     @Test
     fun testThatCleanerPreservesCorrectNumberOfFiles() {
         val numberOfFiles = Random.nextInt(MAX_FILES)
-        LogFileCleaner(logFileProvider, numberOfFiles).clean()
-        assertEquals(numberOfFiles, logFileProvider.getLogFileDirectory().listFiles().count())
+        LogFileCleaner(testProvider, numberOfFiles).clean()
+        assertEquals(numberOfFiles, testProvider.getLogFileDirectory().listFiles().count())
     }
 
     @Test
     fun testThatCleanerErasesAllFilesIfGivenZero() {
-        LogFileCleaner(logFileProvider, 0).clean()
-        assert(logFileProvider.getLogFileDirectory().listFiles().isEmpty())
+        LogFileCleaner(testProvider, 0).clean()
+        assert(testProvider.getLogFileDirectory().listFiles().isEmpty())
     }
 }

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
@@ -3,27 +3,21 @@ package org.wordpress.android.util
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
-import java.io.File
-import java.util.UUID
 import org.junit.After
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.util.helpers.logfile.LogFileProvider
+import java.io.File
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileHelpersTest {
-    private lateinit var testProvider: LogFileProvider
-
-    @Before
-    fun setup() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        testProvider = LogFileProvider.fromContext(context)
-    }
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val testProvider = LogFileProvider.fromContext(context)
 
     @After
     fun tearDown() {

--- a/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
+++ b/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
@@ -3,28 +3,22 @@ package org.wordpress.android.util
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
-import java.io.FileReader
-import java.util.UUID
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.util.helpers.logfile.LogFileProvider
 import org.wordpress.android.util.helpers.logfile.LogFileWriter
+import java.io.FileReader
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileWriterTest {
-    private lateinit var testProvider: LogFileProvider
-
-    @Before
-    fun setup() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        testProvider = LogFileProvider.fromContext(context)
-    }
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val testProvider = LogFileProvider.fromContext(context)
 
     @After
     fun tearDown() {

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,23 @@ ext {
 }
 
 ext {
+    // libs
+    wordpressLintVersion = '1.1.0'
+
+    // main
     androidxCoreVersion = '1.5.0'
+    androidxRecyclerViewVersion = '1.0.0'
+    androidxSwipeRefreshLayoutVersion = '1.1.0'
+    commonsTextVersion = '1.1'
+    eventBusVersion = '3.3.1'
+    materialVersion = '1.2.1'
+    volleyVersion = '1.2.0'
+
+    // test
+    androidxTestCoreVersion = '1.4.0'
+    assertjVersion = '3.11.1'
+    junitVersion = '4.12'
+    jUnitExtVersion = '1.1.3'
+    robolectricVersion = '4.9'
+    uiAutomatorVersion = '2.1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,7 @@ ext {
     compileSdkVersion = 31
     targetSdkVersion = 31
 }
+
+ext {
+    androidxCoreVersion = '1.5.0'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
+    id "com.android.library" apply false
+    id "org.jetbrains.kotlin.android" apply false
     id "com.automattic.android.fetchstyle"
 }
 
@@ -15,6 +19,11 @@ allprojects {
         checkstyle {
             toolVersion = '8.3'
             configFile file("${project.rootDir}/config/checkstyle.xml")
+        }
+    }
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            allWarningsAsErrors = true
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.5.10'
+    gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
 
     plugins {


### PR DESCRIPTION
This PR upgrades Kotlin to `1.6.10`.

FYI: This update isn't that necessary, but should be considered anyway as it will do the following:
- Align this library, to that Kotlin version, which is already used by most of this library's clients and libraries.
- Fix the `NoClassDefFoundError` non-fatal error while assembling the build and more specifically while running the 'compileKotlin' task. For more info see commit description: fd732dbdaea7fabfe61f634d397b80c8e143b399

-----

It also included the following:
- [Update robolectric to 4.9.](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/07a423a13ed1f1b4595757e279b7b6a502cf8dc8) This is done because otherwise Unit Tests are failing to run.
- [Enable all warnings as errors for all modules.](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/be34ead7ac3b6f02cf95a0c883cd1dfcfeb9957e) This is an easy quick win that 1e0d32e07ee46e3622bde74f7a7b17d5854986e5 + ac39d95b431147e0e7a1c4ca82cea59fda76faa7 enables.
- [Extract all dependency version to root build gradle.](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/4e0e865f12e04047dcee9717437d7a202403d835) This is another quick win to organize and group this library's dependency versions.

-----

PS: @hichamboushaba @ovitrif I added you as the main reviewers, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from either, the `WordPress` and `Woo Commerce` teams, to sign-off on that change for WPAndroid or WCAndroid.

-----

### Test

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test, either the `WordPress` or `Woo Commerce` apps, with this version of `Utils`, and see if it works as expected.
    - Test for build time increases (local & CI).