### PR TITLE
Update Apache Commons Text to 1.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     androidxCoreVersion = '1.5.0'
     androidxRecyclerViewVersion = '1.0.0'
     androidxSwipeRefreshLayoutVersion = '1.1.0'
-    commonsTextVersion = '1.1'
+    commonsTextVersion = '1.10.0'
     eventBusVersion = '3.3.1'
     materialVersion = '1.2.1'
     volleyVersion = '1.2.0'


### PR DESCRIPTION
After an internal discussion (see `peaMlT-2f-p2` and `peaMlT-2f-p2#comment-85`, this PR upgrades Apache's `Commons Text` library to [1.10.0](https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0) in order fix the possible `StringSubstitutor` related vulnerability in the library.

For more details see: https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0

And more specifically see release notes entry below:

```
Make default string lookups configurable via system property. Remove
dns, url, and script lookups from defaults. If these lookups are
required for use in StringSubstitutor.createInterpolator(), they must be
enabled via system property. See StringLookupFactory for details.
```

-----

FYI

1. A quick diff of the previous usage of `commons-lang3-3.8.1` vs. the current usage of `commons-lang3-3.12.0` showed no diff for the only 2 `ArrayUtils.toObject(...)` and `ArrayUtils.toPrimitive(...)` utility methods that are used within the `ListUtils.java` class.
2. As per the other such PRs (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/17501), [here](https://github.com/woocommerce/woocommerce-android/pull/7694) and [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573)), a quick diff of the previous usage of `commons-text-1.1` vs. the current usage of `commons-text-1.10.0` showed no diff for the only 1 `StringEscapeUtils.unescapeHtml4(...)` utility method that is used within both, the `HtmlUtils.java` and `JSONUtils.java` classes.

-----

### Test

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test, either the `WordPress` or `Woo Commerce` apps, with this version of `Utils`, and see if it works as expected.

-----

### Merge instructions

- [x] Wait for #113 to be approved and merged to `trunk`.
- [x] Make sure this PR's base is automatically updated to `trunk`.
- [x] Update PR with latest `trunk`.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Merge PR to `trunk`.