### PR TITLE
[Build] Remove Fetch Style Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id "com.android.library" apply false
     id "org.jetbrains.kotlin.android" apply false
-    id "com.automattic.android.fetchstyle"
 }
 
 allprojects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,14 +18,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
     }
-    resolutionStrategy {
-        eachPlugin {
-            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
-        }
-    }
 }
 
 include ':WordPressUtils'


### PR DESCRIPTION
This PR removes the [fetchstyle](https://github.com/Automattic/style-config-android) plugin from the project.

This `style-config-android` plugin is mostly unused and very outdated.

To the Apps Infra's knowledge and checking GE stats no-one is using the `./gradlew downloadConfigs` task to fetch/update the style config files. For years now, almost all Android engineers depend on the default AS style and such like `.idea` configuration.

PS: For more info please refer to this internal discussion here: `C02QANACA/p1667910471807479`

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could try and run the `./gradlew downloadConfigs` task and verify that it is no longer found in the root project for Utils.