### PR TITLE
Use Android AMI in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,19 +1,12 @@
-common-params:
-  &docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.2.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#2.11.0
 
 steps:
   - label: "Lint & Checkstyle"
     key: "lint_and_checkstyle"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew lint checkstyle
@@ -23,8 +16,7 @@ steps:
 
   - label: "Test"
     key: "test"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew test
@@ -33,8 +25,7 @@ steps:
     depends_on:
       - "lint_and_checkstyle"
       - "test"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew \


### PR DESCRIPTION
This PR switches Buildkite builds from Docker to Android AMI. This is a change we have made in most of our repositories, but this is one of the repositories that was left behind.

**To test**

If the CI is green, we are good to :shipit: 