### PR TITLE
Fix a flaky crash occurs on FTL tests

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -299,8 +299,11 @@ public class AppLog {
     private static LogEntryList mLogEntries = new LogEntryList();
 
     private static void addEntry(T tag, LogLevel level, String text) {
+        // Create a new listener list to avoid ConcurrentModificationException
+        List<AppLog.AppLogListener> currentListeners = new ArrayList<>(mListeners);
+
         // Call our listeners if any
-        for (AppLogListener listener : mListeners) {
+        for (AppLogListener listener : currentListeners) {
             listener.onLog(tag, level, text);
         }
         // Record entry if enabled


### PR DESCRIPTION
This fixes a flaky crash occurring on **WPAndroid**'s FTL tests by fixing the `ConcurrentModificationException`. (_Internal discussion: p1670886522054369-slack-C011BKNU1V5_)

Crash log (see `at org.wordpress.android.util.AppLog.addEntry(AppLog.java:303)`):
```
11-30 08:43:17.701: I/WordPress-UTILS(8370): --------- beginning of crash
11-30 08:43:17.702: E/AndroidRuntime(8370): FATAL EXCEPTION: pool-18-thread-47
11-30 08:43:17.702: E/AndroidRuntime(8370): Process: org.wordpress.android, PID: 8370
11-30 08:43:17.702: E/AndroidRuntime(8370): org.greenrobot.eventbus.EventBusException: Invoking subscriber failed
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.greenrobot.eventbus.EventBus.handleSubscriberException(EventBus.java:537)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:519)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at java.lang.Thread.run(Thread.java:923)
11-30 08:43:17.702: E/AndroidRuntime(8370): Caused by: java.util.ConcurrentModificationException
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at java.util.ArrayList$Itr.next(ArrayList.java:860)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.wordpress.android.util.AppLog.addEntry(AppLog.java:303)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.wordpress.android.util.AppLog.d(AppLog.java:138)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.wordpress.android.fluxc.utils.AppLogWrapper.d(AppLogWrapper.kt:8)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.wordpress.android.fluxc.tools.CoroutineEngine.launch(CoroutineEngine.kt:60)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.wordpress.android.fluxc.store.EncryptedLogStore.onAction(EncryptedLogStore.kt:79)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at java.lang.reflect.Method.invoke(Native Method)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:517)
11-30 08:43:17.702: E/AndroidRuntime(8370): 	... 5 more
```
I applied a similar solution as 3f157a989ddba723ff77bd621211b029dd92b5ee.

I checked the Sentry logs and couldn't see this crash in the production logs. I see it only on FTL test logs (probably because of the difference in test coroutines or common objects between sessions). Even if this crash doesn't occur on prod, it's safe to take the precaution for `ConcurrentModificationException`.
