### PR TITLE
Add logging tag for Jetpack migration

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -65,7 +65,8 @@ public class AppLog {
         DOMAIN_REGISTRATION,
         FEATURE_ANNOUNCEMENT,
         PREPUBLISHING_NUDGES,
-        MY_SITE_DASHBOARD
+        MY_SITE_DASHBOARD,
+        JETPACK_MIGRATION,
     }
 
     public static final String TAG = "WordPress";


### PR DESCRIPTION
### Description

Related (parent) PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17748

This PR adds a logging tag for Jetpack migration