### PR TITLE
Android 13 migration update compile sdk version to 33

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -650,7 +650,7 @@ public class ImageUtils {
             try {
                 mediaMetadataRetriever.release();
             } catch (Exception e) {
-                AppLog.e(AppLog.T.MEDIA, "The passed video path is invalid: " + videoPath);
+                AppLog.e(AppLog.T.MEDIA, "Failed to release mediaMetadataRetriever.", e);
             }
         }
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -647,7 +647,11 @@ public class ImageUtils {
             // I've see this kind of error on one of my testing device
             AppLog.e(AppLog.T.MEDIA, "The passed video path is invalid: " + videoPath);
         } finally {
-            mediaMetadataRetriever.release();
+            try {
+                mediaMetadataRetriever.release();
+            } catch (Exception e) {
+                AppLog.e(AppLog.T.MEDIA, "The passed video path is invalid: " + videoPath);
+            }
         }
 
         if (bitmap == null) {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 31
+    compileSdkVersion = 33
     targetSdkVersion = 31
 }
 


### PR DESCRIPTION
Update compileSdkVersion to 33

Internal project thread: pbArwn-5IN-p2

Fixes: [#18095](https://github.com/wordpress-mobile/WordPress-Utils-Android/issues/123)

- Checkout this branch
- Use this branch through WP (uncomment localWPUtilsPath in local-builds.gradle file at the root of app)
- Try out various flows
- Ensure, no issues or crashes

