### PR TITLE
[Build] Enable Non-Transitive Resources

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew lint checkstyle
+      ./gradlew lintRelease checkstyle
     artifact_paths:
       - "**/build/reports/lint-results.*"
       - "**/build/reports/checkstyle/checkstyle.*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew test
+      ./gradlew testRelease
 
   - label: "Build and upload to S3"
     depends_on:

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -26,11 +26,11 @@ dependencies {
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
 
     lintChecks "org.wordpress:lint:$wordpressLintVersion"
+
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
-
 }
 
 android {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
-    androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
 }
 
 android {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation "org.greenrobot:eventbus:$eventBusVersion"
 
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,9 @@ ext {
     androidxTestCoreVersion = '1.4.0'
     assertjVersion = '3.11.1'
     junitVersion = '4.12'
-    jUnitExtVersion = '1.1.3'
     robolectricVersion = '4.9'
+
+    // android test
+    jUnitExtVersion = '1.1.3'
     uiAutomatorVersion = '2.1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,5 +54,4 @@ ext {
 
     // android test
     jUnitExtVersion = '1.1.3'
-    uiAutomatorVersion = '2.1.2'
 }

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -2,3 +2,5 @@
 
 android.useAndroidX=true
 android.enableJetifier=false
+
+android.nonTransitiveRClass=true

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,3 +1,4 @@
 # WordPress-Utils-Android properties.
 
 android.useAndroidX=true
+android.enableJetifier=false

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,1 +1,3 @@
+# WordPress-Utils-Android properties.
+
 android.useAndroidX=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,12 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
+    gradle.ext.automatticPublishToS3Version = '0.7.0'
 
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.publish-to-s3" version gradle.ext.automatticPublishToS3Version
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR is a prerequisite for the `Gradle 8.1.1 & AGP 8.0.2 Upgrade for WPAndroid, WCAndroid & Related Libs` project.

Platform Request: `pdnsEh-13V-p2`
Project Thread: `paaHJt-57Z-p2`

-----

This PR enables non-transitive resources (`android.nonTransitiveRClass`) for the project.

FYI: This behavior becomes the default in AGP `8.0` and higher. As such, this becomes a prerequisite for the AGP `8.0.2` upgrade, that is of course, unless `android.nonTransitiveRClass` is explicitly set to `false`.

-----

Lint Restructure List:

1. [Change lint to lint release check](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/1b9a702b8476e3365d8eb95575b72fe2f2f90b61)

Test Restructure List:

1. [Change test to test release check](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/af7ab8b837b21fc628caf4d9140af3c7ee654cd9)

Dependency Versions Refactor List:

1. [Remove unnecessary kotlin stdlib dependency](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/e45672b27e7ab5cef5dd1bb318d2e1b2c5f9694c)
2. [Extract automattic publish to s3 version to settings build gradle](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/ecbed77ed952cd937899a2d897a324cf5382b3c4)
3. [Move android test specific version to android test versions group](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/fe766041b36341627cc3dc70016fef00bef47987)
4. [Remove unnecessary ui automator dependency](https://github.com/wordpress-mobile/WordPress-Utils-Android/commit/ff353f39a9e82b90263c1e828c0f9c3fcb18278f)

-----

## To test:

1. Verify that all the CI checks are successful.