### PR TITLE
Update publish-to-s3 Gradle plugin to 0.9.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '8.1.0'
-    gradle.ext.automatticPublishToS3Version = '0.8.0'
+    gradle.ext.automatticPublishToS3Version = '0.9.0'
 
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion


### PR DESCRIPTION
There are no functional changes between `0.8.0` & `0.9.0`, but I used this PR to test the changes, so I wanted to proceed with the update to close the loop.