### PR TITLE
[Nullability Annotations to Java Classes] Update `wordPressLintVersion` to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
 
 ext {
     // libs
-    wordpressLintVersion = '1.1.0'
+    wordpressLintVersion = '2.0.0'
 
     // main
     androidxCoreVersion = '1.5.0'


### PR DESCRIPTION
This PR updates `wordPressLintVersion` to [2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0).

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the Lint related [check](https://buildkite.com/automattic/wordpress-utils-android/builds/217#018b6182-583b-4132-9a70-268b5e87d8ef) and its [report](N/A)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshot below:

![image](https://github.com/wordpress-mobile/WordPress-Utils-Android/assets/9729923/3c3c6b3e-e17a-4ee5-8106-b7de2a882a77)
