### PR TITLE
Gravatar sha256 support

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
@@ -68,9 +68,9 @@ public class GravatarUtils {
 
     public static String gravatarFromEmail(final String email, int size, DefaultImage defaultImage) {
         return "http://gravatar.com/avatar/"
-               + StringUtils.getMd5Hash(StringUtils.notNullStr(email))
+               + StringUtils.getSha256Hash(StringUtils.notNullStr(email))
                + "?d=" + defaultImage.toString()
-               + "&size=" + Integer.toString(size);
+               + "&size=" + size;
     }
 
     public static String blavatarFromUrl(final String url, int size) {
@@ -79,8 +79,8 @@ public class GravatarUtils {
 
     public static String blavatarFromUrl(final String url, int size, DefaultImage defaultImage) {
         return "http://gravatar.com/blavatar/"
-               + StringUtils.getMd5Hash(UrlUtils.getHost(url))
+               + StringUtils.getSha256Hash(UrlUtils.getHost(url))
                + "?d=" + defaultImage.toString()
-               + "&size=" + Integer.toString(size);
+               + "&size=" + size;
     }
 }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -139,6 +139,26 @@ public class StringUtils {
         return md5;
     }
 
+    public static BigInteger getSha256IntHash(String input) {
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            byte[] messageDigest = sha256.digest(input.getBytes());
+            return new BigInteger(1, messageDigest);
+        } catch (NoSuchAlgorithmException e) {
+            AppLog.e(T.UTILS, e);
+            return null;
+        }
+    }
+
+    public static String getSha256Hash(String input) {
+        BigInteger number = getSha256IntHash(input);
+        String sha256 = number.toString(16);
+        while (sha256.length() < 64) {
+            sha256 = "0" + sha256;
+        }
+        return sha256;
+    }
+
     /*
      * nbradbury - adapted from Html.escapeHtml(), which was added in API Level 16
      * TODO: not thoroughly tested yet, so marked as private - not sure I like the way


### PR DESCRIPTION
Gravatar is moving away from md5 to sha256. This PR adds the methods for using sha256. Note: the existing md5 methods are used for reasons other than gravatar, so they are staying put.

See pb6Nl-gyD-p2 for additional info

WP/JP Android companion app for testing can be found https://github.com/wordpress-mobile/WordPress-Android/pull/19846