### PR TITLE
MediaUtils - Add support for heic and heif image formats

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -43,7 +43,7 @@ public class MediaUtils {
         }
         url = url.toLowerCase(Locale.ROOT);
         return url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg") || url.endsWith(".gif")
-               || url.endsWith(".webp");
+               || url.endsWith(".webp") || url.endsWith(".heic") || url.endsWith(".heif");
     }
 
     public static boolean isDocument(String url) {


### PR DESCRIPTION
This PR adds support for the `heic` and `heif` image extensions in `isValidImage`, to match the [currently supported formats](https://wordpress.com/support/accepted-filetypes/#images).