### PR TITLE
Fallback to original URL if the beginIndex is invalid

### DIFF
--- a/WordPressUtils/src/androidTest/java/org/wordpress/android/util/PhotonUtilsTest.java
+++ b/WordPressUtils/src/androidTest/java/org/wordpress/android/util/PhotonUtilsTest.java
@@ -109,6 +109,6 @@ public class PhotonUtilsTest {
         String imageUrl = "mysite.com/test.jpg#http://another.com";
         String photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, 1, 1);
 
-        assertThat(photonUrl, equalTo("mysite.com/test.jpg"));
+        assertThat(photonUrl, equalTo(imageUrl));
     }
 }

--- a/WordPressUtils/src/androidTest/java/org/wordpress/android/util/PhotonUtilsTest.java
+++ b/WordPressUtils/src/androidTest/java/org/wordpress/android/util/PhotonUtilsTest.java
@@ -103,4 +103,12 @@ public class PhotonUtilsTest {
 
         assertThat(photonUrl, equalTo("https://i0.wp.com/mysite.com/test.jpg?strip=info&quality=65&resize=2,1&ssl=1"));
     }
+
+    @Test
+    public void getPhotonImageUrlWithErroneousSchemePosition() {
+        String imageUrl = "mysite.com/test.jpg#http://another.com";
+        String photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, 1, 1);
+
+        assertThat(photonUrl, equalTo("mysite.com/test.jpg"));
+    }
 }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -52,6 +52,8 @@ public class PhotonUtils {
             return "";
         }
 
+        String originalUrl = imageUrl;
+
         // make sure it's valid
         int schemePos = imageUrl.indexOf("://");
         if (schemePos == -1) {
@@ -142,7 +144,7 @@ public class PhotonUtils {
         if (beginIndex < 0 || beginIndex > imageUrl.length()) {
             // Fallback to original URL if the beginIndex is invalid to avoid `StringIndexOutOfBoundsException`
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/18626
-            return imageUrl;
+            return originalUrl;
         }
         return "https://i0.wp.com/" + imageUrl.substring(beginIndex) + query;
     }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -140,7 +140,7 @@ public class PhotonUtils {
 
         int beginIndex = schemePos + 3;
         if (beginIndex < 0 || beginIndex > imageUrl.length()) {
-            // Fallback to original URL if the beginIndex is invalid
+            // Fallback to original URL if the beginIndex is invalid to avoid `StringIndexOutOfBoundsException`
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/18626
             return imageUrl;
         }

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -138,6 +138,12 @@ public class PhotonUtils {
             query += "&ssl=1";
         }
 
-        return "https://i0.wp.com/" + imageUrl.substring(schemePos + 3, imageUrl.length()) + query;
+        int beginIndex = schemePos + 3;
+        if (beginIndex < 0 || beginIndex > imageUrl.length()) {
+            // Fallback to original URL if the beginIndex is invalid
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/18626
+            return imageUrl;
+        }
+        return "https://i0.wp.com/" + imageUrl.substring(beginIndex) + query;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/18626

**WordPress-Android PR:** https://github.com/wordpress-mobile/WordPress-Android/pull/20459

## Description
Checks the begin index before calling the substring function to prevent the `StringIndexOutOfBoundsException`

## To test
I was not able to reproduce the issue but there are 5 different crashes rooting from this exception (see https://github.com/wordpress-mobile/WordPress-Android/issues/18626#issuecomment-1994469899)
I managed to fake one URL that reproduces the crash and added a test for it.