### PR TITLE
Update WordPress-Lint-Android version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
 
 ext {
     // libs
-    wordpressLintVersion = '2.0.0'
+    wordpressLintVersion = '2.1.0'
 
     // main
     androidxCoreVersion = '1.5.0'


### PR DESCRIPTION
### Description

This PR bumps the version of WordPress-Lint-Android to [`2.1.0`](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.1.0), which [fixes an issue](https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/19) with false positives when warning about missing null annotations for enums.

#### Test

In Android Studio, navigate to a Java file that has an enum declaration. It should no longer warn about missing null annotations for the enum.