### PR TITLE
Fix NullPointerException in AppLog.addEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In the following cases, the CI will publish a new version with the following for
 
 - [WordPress for Android][2]
 - [FluxC][3]
+- [Woo for Android][4]
 
 ## License
 Dual licensed under MIT, and GPL.
@@ -34,3 +35,4 @@ Dual licensed under MIT, and GPL.
 [1]: https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/a9fbe8e6597d44055ec2180dbf45aecbfc332a20/WordPressUtils/build.gradle#L37
 [2]: https://github.com/wordpress-mobile/WordPress-Android
 [3]: https://github.com/wordpress-mobile/WordPress-FluxC-Android
+[4]: https://github.com/woocommerce/woocommerce-android

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -305,7 +305,12 @@ public class AppLog {
 
         // Call our listeners if any
         for (AppLogListener listener : currentListeners) {
-            listener.onLog(tag, level, text);
+            if (listener != null) {
+                listener.onLog(tag, level, text);
+            } else {
+                // Log a warning
+                w(T.UTILS, "AppLogListener is null when attempting to log.");
+            }
         }
         // Record entry if enabled
         if (mEnableRecording) {


### PR DESCRIPTION
**Description:**

This pull request addresses a [NPE crash](https://github.com/woocommerce/woocommerce-android/issues/11028) that could occur in the `AppLog.addEntry` method when attempting to call `onLog` on a null `AppLogListener` object.

Also contains a small ReadMe update for clarity.

**Problem:**

The `addEntry` method iterated through a list of `AppLogListener` objects without checking for null values. If no listeners were registered, the loop would attempt to call methods on null objects, leading to an NPE.
```
NullPointerException: Attempt to invoke interface method 'void org.wordpress.android.util.AppLog$AppLogListener.onLog(org.wordpress.android.util.AppLog$T, org.wordpress.android.util.AppLog$LogLevel, java.lang.String)' on a null object reference
    at org.wordpress.android.util.AppLog.addEntry(AppLog.java:308)
    at org.wordpress.android.util.AppLog.d(AppLog.java:139)
    at org.wordpress.android.fluxc.utils.AppLogWrapper.d(AppLogWrapper.kt:8)
    at org.wordpress.android.fluxc.tools.CoroutineEngine.launch(CoroutineEngine.kt:60)
    at org.wordpress.android.fluxc.store.EncryptedLogStore.onAction(EncryptedLogStore.kt:79)
...
(7 additional frame(s) were not displayed)

EventBusException: Invoking subscriber failed
    at org.greenrobot.eventbus.EventBus.handleSubscriberException(EventBus.java:537)
    at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:519)
    at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511)
    at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
...
(2 additional frame(s) were not displayed)
```

**Solution:**

Thanks for the help figuring out what to do here @jd-alexander  
I added a simple null check within the loop to ensure we only call `onLog` on valid listeners. If a null listener is encountered, a warning message is logged to indicate the issue. 

It should be noted that the root problem still remains as I was unable to identify it. i.e. why was the listener null in the first place. This solution just addresses the symptom (NPE), not the underlying problem of the absence of the listener.


**Notes:**

An alternative approach would be to filter out null listeners before iterating. I did not implemented in this PR due to a preference for simpler code but I'd be happy to change it if we feel that's more performant. 

