### PR TITLE
[Build] Update Kotlin to 1.9.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ allprojects {
     }
     tasks.withType(KotlinCompile).all {
         kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_1_8
             allWarningsAsErrors = true
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.6.10'
+    gradle.ext.kotlinVersion = '1.9.22'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.9.0'
 


### PR DESCRIPTION
Required By: #148

This PR updates Kotlin to [1.9.22](https://github.com/JetBrains/kotlin/releases/tag/v1.9.22).

### Description

This update isn't that necessary, but should be considered anyway as it will do the following:
- Align this library, to that Kotlin version, which is already used by most of this library's clients and libraries.
- Unblock the usage of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin for this project.
- Prepares this project for the Kotlin 2+ major update.

### Test

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android) apps, with this version of `Utils`, or via composite builds, and see if it works as expected.
    - Test for build time increases (local & CI).