### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
-    androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
 }
 
 android {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     lintChecks "org.wordpress:lint:$wordpressLintVersion"
 
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
-    androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
 }
 
 android {

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeRefreshLayoutVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerViewVersion"
-    implementation "org.greenrobot:eventbus:$eventBusVersion"
+    implementation "org.greenrobot:eventbus-java:$eventBusVersion"
 
     implementation "androidx.core:core:$androidxCoreVersion"
 

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerViewVersion"
     implementation "org.greenrobot:eventbus:$eventBusVersion"
 
-    implementation "androidx.core:core-ktx:$androidxCoreVersion"
+    implementation "androidx.core:core:$androidxCoreVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -12,7 +12,6 @@ repositories {
 
 dependencies {
     implementation "org.apache.commons:commons-text:$commonsTextVersion"
-    implementation "com.android.volley:volley:$volleyVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeRefreshLayoutVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerViewVersion"

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -205,18 +205,18 @@ public class AppLog {
      * Sends a ERROR log message
      * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the
      *           log call occurs.
-     * @param volleyErrorMsg
+     * @param errorMsg
      * @param statusCode
      */
-    public static void e(T tag, String volleyErrorMsg, int statusCode) {
-        if (TextUtils.isEmpty(volleyErrorMsg)) {
+    public static void e(T tag, String errorMsg, int statusCode) {
+        if (TextUtils.isEmpty(errorMsg)) {
             return;
         }
         String logText;
         if (statusCode == -1) {
-            logText = volleyErrorMsg;
+            logText = errorMsg;
         } else {
-            logText = volleyErrorMsg + ", status " + statusCode;
+            logText = errorMsg + ", status " + statusCode;
         }
         Log.e(TAG + "-" + tag.toString(), logText);
         addEntry(tag, LogLevel.w, logText);

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ ext {
     commonsTextVersion = '1.10.0'
     eventBusVersion = '3.3.1'
     materialVersion = '1.2.1'
-    volleyVersion = '1.2.0'
 
     // test
     androidxTestCoreVersion = '1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,4 @@ ext {
     assertjVersion = '3.11.1'
     junitVersion = '4.12'
     robolectricVersion = '4.9'
-
-    // android test
-    jUnitExtVersion = '1.1.3'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.9.0'
-    gradle.ext.dependencyAnalysisVersion = '1.28.0'
+    gradle.ext.dependencyAnalysisVersion = '1.33.0'
 
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion


### PR DESCRIPTION
Project Thread: paaHJt-6YV-p2

### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin, this PR removes all unused dependencies from this project.

FYI: As part of this change, the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin got also updated to its latest [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) version.

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/wordpress-utils-android/builds/264) and verify that everything works as expected with this newer version of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin ([1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)).
3. Testing:
    - Quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `Utils`, or via composite builds, and see if it works as expected.