### PR TITLE
Remove Android dependency from fastStripHtml function

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/HtmlUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/HtmlUtils.java
@@ -37,7 +37,7 @@ public class HtmlUtils {
      * @return String without HTML
      */
     public static String fastStripHtml(String str) {
-        if (TextUtils.isEmpty(str)) {
+        if (str == null || str.isEmpty()) {
             return str;
         }
 


### PR DESCRIPTION
This just makes it easier to use it in tests without any mocks.