### PR TITLE
[Deps] Add Back EventBus Android Dependency

### DIFF
--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeRefreshLayoutVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerViewVersion"
+    implementation "org.greenrobot:eventbus:$eventBusVersion"
     implementation "org.greenrobot:eventbus-java:$eventBusVersion"
 
     implementation "androidx.core:core:$androidxCoreVersion"
@@ -27,6 +28,15 @@ dependencies {
     lintChecks "org.wordpress:lint:$wordpressLintVersion"
 
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
+}
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude("org.greenrobot:eventbus")
+        }
+    }
 }
 
 android {


### PR DESCRIPTION
### Description

This PR adds back the main `EventBus` dependency, which is `Android` related.

This dependency was incorrectly removed and replaced by its corresponding `eventbus-java` transitive dependency, assuming that is not required. However, after further testing it was revealed that this parent `eventbus` dependency, which is actually `android` specific is indeed necessary. If it is not provided on the classpath then an app will crash with the below runtime exception:

```
java.lang.RuntimeException: Unable to create application xyz: java.lang .RuntimeException:
It looks like you are using EventBus on Android, make sure to add the "eventbus" Android
library to your dependencies.
```

For more info see:
- [EventBus.register(...)](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/EventBus.java#L143-L147)
- [!AndroidDependenciesDetector.areAndroidComponentsAvailable()](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/android/AndroidDependenciesDetector.java#L25-L36)

### Testing Instructions

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise related to `eventbus`.
2. Testing:
    - Quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `Utils`, or via composite builds, and see if it works as expected.