### PR TITLE
[PhotonUtils] Add AVIF scenario handling

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -130,7 +130,7 @@ public class PhotonUtils {
 
         // use wordpress.com as the host if image is on wordpress.com since it supports the same
         // query params and, more importantly, can handle images in private blogs
-        if (imageUrl.contains("wordpress.com")) {
+        if (imageUrl.contains("wordpress.com") || imageUrl.contains(".avif")) {
             return imageUrl + query;
         }
 

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -130,7 +130,7 @@ public class PhotonUtils {
 
         // use wordpress.com as the host if image is on wordpress.com since it supports the same
         // query params and, more importantly, can handle images in private blogs
-        if (imageUrl.contains("wordpress.com") || imageUrl.contains(".avif")) {
+        if (imageUrl.contains("wordpress.com") || imageUrl.endsWith(".avif")) {
             return imageUrl + query;
         }
 


### PR DESCRIPTION
Summary
==========
This PR adjusts the `PhotonUtils` URL logic to account for `avif` formats. Since they don't load using the alternative path branching from `https://i0.wp.com/`, when the `avif` format is detected, the URL will be returned only with the addition of the query parameters.

How to Test
==========
Since this change is targeting to provide AVIF support to the WCAndroid app, I suggest testing it through the Woo counterpart PR: https://github.com/woocommerce/woocommerce-android/pull/12835