### PR TITLE
fix: read EXIF orientation directly for plain file paths

### DIFF
--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -90,6 +90,14 @@ public class ImageUtils {
         filePath = filePath.replace("file://", "");
 
         if (!filePath.contains("content://")) {
+            // A plain filesystem path pointing at an existing file (e.g. an app cache file) is not
+            // resolvable through the MediaStore content provider — prefixing it with
+            // "content://media" would produce a bogus Uri whose query always fails (throwing on
+            // some devices). EXIF is the only orientation source such a file has, so read it
+            // directly.
+            if (new File(filePath).exists()) {
+                return getExifOrientation(filePath);
+            }
             curStream = Uri.parse("content://media" + filePath);
         } else {
             curStream = Uri.parse(filePath);

--- a/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -95,8 +95,9 @@ public class ImageUtils {
             // "content://media" would produce a bogus Uri whose query always fails (throwing on
             // some devices). EXIF is the only orientation source such a file has, so read it
             // directly.
-            if (new File(filePath).exists()) {
-                return getExifOrientation(filePath);
+            String existingPath = firstExistingPath(filePath, Uri.decode(filePath));
+            if (existingPath != null) {
+                return getExifOrientation(existingPath);
             }
             curStream = Uri.parse("content://media" + filePath);
         } else {
@@ -123,6 +124,17 @@ public class ImageUtils {
         return orientation;
     }
 
+    /**
+     * Returns the first candidate that names a file on disk, or null when none of them do.
+     */
+    private static String firstExistingPath(String... candidates) {
+        for (String candidate : candidates) {
+            if (!TextUtils.isEmpty(candidate) && new File(candidate).exists()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
 
     private static int getExifOrientation(String path) {
         if (TextUtils.isEmpty(path)) {


### PR DESCRIPTION
## Description

`ImageUtils.getImageOrientation` prefixes any non-`content://` path with `content://media` and queries the MediaStore content provider first, only falling back to reading EXIF when that query returns nothing.

For a **plain filesystem path pointing at an existing file** (e.g. an app cache file), that constructed `Uri` is never resolvable through MediaStore, so the query always fails. On some devices it fails by throwing `IllegalArgumentException: Volume data not found`, which is caught but logged as an **error with a full stack trace on every call**:

```
E  Error reading orientation of the file: /data/user/0/<app>/cache/.../image.jpg
   java.lang.IllegalArgumentException: Volume data not found
       at android.database.DatabaseUtils.readExceptionFromParcel(...)
       ...
       at org.wordpress.android.util.ImageUtils.getImageOrientation(ImageUtils.java:100)
       at org.wordpress.android.util.ImageUtils.optimizeImage(ImageUtils.java:547)
```

The orientation was still resolved correctly (via the EXIF fallback), so this was benign but noisy — and increasingly common now that hosts optimize images staged in their own cache directories (e.g. GutenbergKit's native media upload processing).

## Fix

When the path is a plain filesystem path that points at an existing file, read EXIF orientation directly and skip the doomed provider query. EXIF is the only orientation source such a file has, so this is behavior-preserving. MediaStore-style paths (which don't exist on the filesystem) keep the previous query-then-EXIF-fallback behavior.

## Testing

Verified in a host app (https://github.com/wordpress-mobile/WordPress-Android/pull/23142) that optimizes an image staged in its cache dir: before this change the error + stack trace logged on every upload; after, it's gone and orientation is still applied correctly.

Co-authored with Claude.